### PR TITLE
fix: Mid의 높이를 수정함.

### DIFF
--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -84,7 +84,7 @@ const Result = () => {
 export default Result;
 
 const Mid = styled.div`
-  min-height: 100vh;
+  height: 100vh;
 `;
 
 const State = styled.div`


### PR DESCRIPTION
1. 작업내용
- Result Page의 Mid의 높이 속성을 min-height에서 height로 변경했습니다.
- 기존에 윗부분이 잘리던 현상이 수정되었습니다.
<img src="https://user-images.githubusercontent.com/12118892/228452269-d4bf920e-a50f-4828-8665-0cd058e50b17.png" width="30%"><img src="https://user-images.githubusercontent.com/12118892/228452337-a743bb9a-265e-41fc-ab51-602dbabe4cf0.png" width="30%">

2. 의견 필요
- 기존에 잘리던 부분이 정상적으로 출력되긴 하나 정확한 이유를 모르겠습니다. 기존에는 화면 비율100%로 볼 경우 윗부분이 잘려서 보였고, 화면 비율을 축소할 경우 잘린 부분이 정상적으로 보였습니다. 
 DustState컴포넌트나 '지역별 미세먼지 농도 순위' 에 관한 내용이 그려지기 전에 Mid가 먼저 min-height = 100vh 로 그려지기 때문에 Mid 이후에 그려진 내용들이 화면 밖으로 밀려났던 것이라고 생각됩니다. 해당 내용과 관련해서 읽어 볼만한 자료나 설명을 알고 계신다면 알려주세요!
