### PR TITLE
refactor: useFetch 분리 / result page 결과값 수정

### DIFF
--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -19,7 +19,7 @@ const ProgressBar = ({ children, id, state }: ProgressBarProps) => (
     </DustWrapperFlex>
     <ProgressWrapper>
       <Progress
-        percent={state}
+        percent={+state * (1 / 1000) * 100}
         theme={{
           success: {
             symbol: ' ',

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -24,28 +24,32 @@ export const cityGroup = [
   { cityName: '세종', cityNumber: 16 },
 ];
 
-const useFetch = async () => {
+const useFetch = () => {
   const [data, setData] = useState<dustDataType | []>([]);
 
-  useEffect(() => {
-    Promise.all(
+  const fetchData = async () => {
+    const result = await Promise.all(
       cityGroup.map((v) =>
         axios
           .get(
             `${VITE_OPEN_URL}?sidoName=${v.cityName}&pageNo=1&numOfRows=100&returnType=json&serviceKey=${VITE_API_KEY}&ver=1.0`
           )
           .then((res) => {
-            console.log(res);
             return res.data.response.body;
           })
       )
-    ).then((res) => {
-      setData(res);
-      return res;
-    });
+    );
+
+    setData(result);
+  };
+
+  useEffect(() => {
+    fetchData();
   }, []);
 
-  return data;
+  if (!data[0]) fetchData();
+
+  return { data, fetchData };
 };
 
 export default useFetch;

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -25,7 +25,7 @@ export const cityGroup = [
 ];
 
 const useFetch = () => {
-  const [data, setData] = useState<DustDataType | []>([]);
+  const [data, setData] = useState<DustDataType[] | []>([]);
 
   const fetchData = async () => {
     const result = await Promise.all(

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
-import { dustDataType } from '@/type';
+import { DustDataType } from '@/type';
 
 const { VITE_API_KEY, VITE_OPEN_URL } = import.meta.env;
 
@@ -25,7 +25,7 @@ export const cityGroup = [
 ];
 
 const useFetch = () => {
-  const [data, setData] = useState<dustDataType | []>([]);
+  const [data, setData] = useState<DustDataType | []>([]);
 
   const fetchData = async () => {
     const result = await Promise.all(

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
+import { dustDataType } from '@/type';
 
 const { VITE_API_KEY, VITE_OPEN_URL } = import.meta.env;
 
@@ -24,19 +25,24 @@ export const cityGroup = [
 ];
 
 const useFetch = async () => {
-  const [data, setData] = useState({});
+  const [data, setData] = useState<dustDataType | []>([]);
+
   useEffect(() => {
-    setData(
-      Promise.all(
-        cityGroup.map((v) =>
-          axios
-            .get(
-              `${VITE_OPEN_URL}?sidoName=${v.cityName}&pageNo=1&numOfRows=100&returnType=json&serviceKey=${VITE_API_KEY}&ver=1.0`
-            )
-            .then((data) => data.data.response.body)
-        )
-      ).then((data) => data)
-    );
+    Promise.all(
+      cityGroup.map((v) =>
+        axios
+          .get(
+            `${VITE_OPEN_URL}?sidoName=${v.cityName}&pageNo=1&numOfRows=100&returnType=json&serviceKey=${VITE_API_KEY}&ver=1.0`
+          )
+          .then((res) => {
+            console.log(res);
+            return res.data.response.body;
+          })
+      )
+    ).then((res) => {
+      setData(res);
+      return res;
+    });
   }, []);
 
   return data;

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -10,7 +10,7 @@ import useFetch, { cityGroup } from '../hooks/useFetch';
 import { DustDataType } from '@/type';
 
 const Result = () => {
-  const [dustData, setDustData] = useState<DustDataType | []>([]);
+  const [dustData, setDustData] = useState<DustDataType[] | []>([]);
   const location = useLocation();
   const choiceCity = location.state;
 
@@ -19,23 +19,49 @@ const Result = () => {
     setDustData(data);
   }, [data]);
 
-  const findChoiceCity = (kindOfdust: string) => {
+  const findChoiceCity = (kindOfDust: string) => {
     const result = dustData.find(
       (temp) => temp.items[0].sidoName === choiceCity
     );
 
     if (!result) return '';
 
-    switch (kindOfdust) {
+    return calculateFineDust({ result, kindOfDust });
+
+    // switch (kindOfDust) {
+    //   case 'DustState':
+    //     return (
+    //       (parseInt(result?.items[4]?.pm10Grade) +
+    //         parseInt(result?.items[4]?.pm25Grade)) /
+    //       2
+    //     ).toString();
+    //   case 'first':
+    //     return result?.items[4]?.pm10Value;
+    //   case 'last':
+    //     return result?.items[4]?.pm25Value;
+    //   default:
+    //     return '';
+    // }
+  };
+  // fine dust
+
+  const calculateFineDust = ({
+    result,
+    kindOfDust,
+  }: {
+    result: DustDataType;
+    kindOfDust: string;
+  }) => {
+    switch (kindOfDust) {
       case 'DustState':
         return (
           (parseInt(result?.items[4]?.pm10Grade) +
             parseInt(result?.items[4]?.pm25Grade)) /
           2
         ).toString();
-      case 'first':
+      case 'fineDust':
         return result?.items[4]?.pm10Value;
-      case 'last':
+      case 'ultraFineDust':
         return result?.items[4]?.pm25Value;
       default:
         return '';
@@ -53,10 +79,10 @@ const Result = () => {
         <Location>{choiceCity}</Location>
         <Text>현재의 대기질 지수는</Text>
         <DustState dustState={findChoiceCity('DustState')} />
-        <Progress id="first" state={findChoiceCity('first')}>
+        <Progress id="fineDust" state={findChoiceCity('fineDust')}>
           미세먼지
         </Progress>
-        <Progress id="last" state={findChoiceCity('last')}>
+        <Progress id="ultraFineDust" state={findChoiceCity('ultraFineDust')}>
           초미세먼지
         </Progress>
       </Middle>

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -14,8 +14,10 @@ const Result = () => {
   const location = useLocation();
   const choiceCity = location.state;
 
-  const data = useFetch();
-  data.then((data) => setDustData(data));
+  const { data, fetchData } = useFetch();
+  useEffect(() => {
+    setDustData(data);
+  }, [data]);
 
   const findChoiceCity = (kindOfdust: string) => {
     const result = dustData.find(

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -7,10 +7,10 @@ import Progress from '../components/Progress';
 import Rank from '../components/Rank';
 import useFetch, { cityGroup } from '../hooks/useFetch';
 
-import { dustDataType } from '@/type';
+import { DustDataType } from '@/type';
 
 const Result = () => {
-  const [dustData, setDustData] = useState<dustDataType | []>([]);
+  const [dustData, setDustData] = useState<DustDataType | []>([]);
   const location = useLocation();
   const choiceCity = location.state;
 

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -9,27 +9,13 @@ import useFetch, { cityGroup } from '../hooks/useFetch';
 
 import { dustDataType } from '@/type';
 
-import axios from 'axios';
-const { VITE_API_KEY, VITE_OPEN_URL } = import.meta.env;
-
 const Result = () => {
-  // const data = useFetch();
   const [dustData, setDustData] = useState<dustDataType | []>([]);
   const location = useLocation();
   const choiceCity = location.state;
 
-  // data.then((data) => setDustData(data));
-  useEffect(() => {
-    Promise.all(
-      cityGroup.map((v) =>
-        axios
-          .get(
-            `${VITE_OPEN_URL}?sidoName=${v.cityName}&pageNo=1&numOfRows=100&returnType=json&serviceKey=${VITE_API_KEY}&ver=1.0`
-          )
-          .then((res) => res.data.response.body)
-      )
-    ).then((data) => setDustData(data));
-  }, [location]);
+  const data = useFetch();
+  data.then((data) => setDustData(data));
 
   return (
     <Mid>

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -24,15 +24,17 @@ const Result = () => {
       (temp) => temp.items[0].sidoName === choiceCity
     );
 
-    if (result && kindOfdust === 'DustState') {
+    if (!result) return;
+
+    if (kindOfdust === 'DustState') {
       return (
         (parseInt(result?.items[4]?.pm10Grade) +
           parseInt(result?.items[4]?.pm25Grade)) /
         2
       ).toString();
-    } else if (result && kindOfdust === 'first') {
+    } else if (kindOfdust === 'first') {
       return result?.items[4]?.pm10Value;
-    } else if (result && kindOfdust === 'last') {
+    } else if (kindOfdust === 'last') {
       return result?.items[4]?.pm25Value;
     } else return '';
   };

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -24,26 +24,10 @@ const Result = () => {
       (temp) => temp.items[0].sidoName === choiceCity
     );
 
-    if (!result) return '';
+    if (!result) return '0';
 
     return calculateFineDust({ result, kindOfDust });
-
-    // switch (kindOfDust) {
-    //   case 'DustState':
-    //     return (
-    //       (parseInt(result?.items[4]?.pm10Grade) +
-    //         parseInt(result?.items[4]?.pm25Grade)) /
-    //       2
-    //     ).toString();
-    //   case 'first':
-    //     return result?.items[4]?.pm10Value;
-    //   case 'last':
-    //     return result?.items[4]?.pm25Value;
-    //   default:
-    //     return '';
-    // }
   };
-  // fine dust
 
   const calculateFineDust = ({
     result,
@@ -64,7 +48,7 @@ const Result = () => {
       case 'ultraFineDust':
         return result?.items[4]?.pm25Value;
       default:
-        return '';
+        return '0';
     }
   };
 

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -26,17 +26,20 @@ const Result = () => {
 
     if (!result) return '';
 
-    if (kindOfdust === 'DustState') {
-      return (
-        (parseInt(result?.items[4]?.pm10Grade) +
-          parseInt(result?.items[4]?.pm25Grade)) /
-        2
-      ).toString();
-    } else if (kindOfdust === 'first') {
-      return result?.items[4]?.pm10Value;
-    } else if (kindOfdust === 'last') {
-      return result?.items[4]?.pm25Value;
-    } else return '';
+    switch (kindOfdust) {
+      case 'DustState':
+        return (
+          (parseInt(result?.items[4]?.pm10Grade) +
+            parseInt(result?.items[4]?.pm25Grade)) /
+          2
+        ).toString();
+      case 'first':
+        return result?.items[4]?.pm10Value;
+      case 'last':
+        return result?.items[4]?.pm25Value;
+      default:
+        return '';
+    }
   };
 
   return (

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -24,7 +24,7 @@ const Result = () => {
       (temp) => temp.items[0].sidoName === choiceCity
     );
 
-    if (!result) return;
+    if (!result) return '';
 
     if (kindOfdust === 'DustState') {
       return (

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -7,7 +7,7 @@ import Progress from '../components/Progress';
 import Rank from '../components/Rank';
 import useFetch, { cityGroup } from '../hooks/useFetch';
 
-import { DustDataType } from '@/type';
+import { type DustData } from '@/type';
 
 const Result = () => {
   const [dustData, setDustData] = useState<DustDataType[] | []>([]);

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -33,7 +33,7 @@ const Result = () => {
     result,
     kindOfDust,
   }: {
-    result: DustDataType;
+    result: DustData;
     kindOfDust: string;
   }) => {
     switch (kindOfDust) {

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -17,6 +17,24 @@ const Result = () => {
   const data = useFetch();
   data.then((data) => setDustData(data));
 
+  const findChoiceCity = (kindOfdust: string) => {
+    const result = dustData.find(
+      (temp) => temp.items[0].sidoName === choiceCity
+    );
+
+    if (result && kindOfdust === 'DustState') {
+      return (
+        (parseInt(result?.items[4]?.pm10Grade) +
+          parseInt(result?.items[4]?.pm25Grade)) /
+        2
+      ).toString();
+    } else if (result && kindOfdust === 'first') {
+      return result?.items[4]?.pm10Value;
+    } else if (result && kindOfdust === 'last') {
+      return result?.items[4]?.pm25Value;
+    } else return '';
+  };
+
   return (
     <Mid>
       <State>전국 미세먼지 농도는 다음과 같습니다</State>
@@ -27,17 +45,11 @@ const Result = () => {
       <Middle>
         <Location>{choiceCity}</Location>
         <Text>현재의 대기질 지수는</Text>
-        <DustState
-          dustState={(
-            (parseInt(dustData[0]?.items[4]?.pm10Grade) +
-              parseInt(dustData[0]?.items[4]?.pm25Grade)) /
-            2
-          ).toString()}
-        />
-        <Progress id="first" state={dustData[0]?.items[4]?.pm10Value}>
+        <DustState dustState={findChoiceCity('DustState')} />
+        <Progress id="first" state={findChoiceCity('first')}>
           미세먼지
         </Progress>
-        <Progress id="last" state={dustData[0]?.items[4]?.pm25Value}>
+        <Progress id="last" state={findChoiceCity('last')}>
           초미세먼지
         </Progress>
       </Middle>

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -6,6 +6,7 @@ export type dustDataType = {
     pm25Value: string;
     pm10Grade: string;
     pm25Grade: string;
+    sidoName: string;
   }[];
   numOfRows: number;
   totalCount: number;

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,4 +1,4 @@
-export type DustDataType = {
+export type DustData = {
   items: {
     dataTime: string;
     stationName: string;

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,4 +1,4 @@
-export type dustDataType = {
+export type DustDataType = {
   items: {
     dataTime: string;
     stationName: string;

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -11,4 +11,4 @@ export type DustDataType = {
   numOfRows: number;
   totalCount: number;
   pageNo: number;
-}[];
+};


### PR DESCRIPTION
1. 작업내용
- Result Page에 함께 있던 useFetch 함수를 다시 분리했습니다.
- Choice 화면에서 선택한 도시와 상관없이 Result 화면 상단에 표기되는 값이 일정했었습니다. 이제는 선택한 도시에 대한 정보가 표기됩니다. 
![image](https://user-images.githubusercontent.com/12118892/228505087-20511f0a-a0f1-4eb2-b855-ba2754dcce3a.png)
이전에는 어느 도시를 선택하든 통신결과 0번 째 인덱스에 해당하는 정보(도시 이름 제외)가 표기되었습니다.
- Progress 컴포넌트의 계산 방법을 수정했습니다. 미세먼지 수치가 100을 넘어가는 경우 Progress bar가 화면 밖으로 나가는 현상이 있었습니다. 기상청 통계 결과 역대 가장 심했던 서울의 미세먼지 농도는 1060㎍/㎥ 이상 이었습니다. 이는 역대 가장 높은 수치 였으므로 특별한 경우가 아니라면 1000㎍/㎥ 가 넘는 경우는 자주 발생하지 않을것으로 사료됩니다.
이에 따라 Progress bar의 계산식을 1/1000 으로 계산하도록 수정했습니다. 
![image](https://user-images.githubusercontent.com/12118892/228505902-45308ac7-4e61-44e3-85ca-76cb1405ac21.png)

2. 의견 필요
- 데이터를 다시 패칭하여 useFetch의 data State를 갱신하는 reFetch 함수를 useFetch안에 만들고 싶었습니다. 그리고 ```return {data , refetch }``` 와 같은 모습으로 만드려했습니다 만, 받는 쪽에서 type 문제를 해결하지 못하여서 우선 제외하고 PR을 날립니다. promiseAll 의 사용도 처음이라 어떤 방식으로 구현해야 할지 의견 주시면 감사하겠습니다. 
- 서비스 제목이 '"랭킹"먼지' 이므로 미세 먼지 농도 순위와 맞게 result page가 보여져야 한다고 생각됩니다. '미세먼지' + '초미세먼지' 값 등 다양한 sort 기준이 있을 것 같은데 어떤 기준이 적절할까요?

3. 추후 변경 
- 현재 각 지역에 대한 미세먼지 값은 각 '도'에 속한 지역중 4번 인덱스에 해당하는 값으로 보여집니다. 이를 계산하는 방식으로 각 '도'에 해당하는 더 작은 지역들의 미세먼지 평균값을 보여주는 것이 더 바람직하다고 생각되나 수정사항이 너무 많아지므로 현 PR 에서는 제외하였습니다.



