### PR TITLE
fix: 마커가 계속 생성되는 문제 해결

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -18,6 +18,7 @@ const INIT_ZOOM_LEVEL = 5;
 
 const Map = () => {
   const mapRef = useRef<HTMLDivElement>(null);
+  const dustInfoMarkers: kakao.maps.CustomOverlay[] = [];
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
   const [location, setLocation] = useState(INIT_LOCATION);
   const [zoomLevel, setZoomLevel] = useState(INIT_ZOOM_LEVEL);
@@ -106,17 +107,34 @@ const Map = () => {
           content: template,
         });
 
-        marker.setMap(map);
-
-        map.setCenter(
-          new kakao.maps.LatLng(
-            CENTER_LOCATION.latitude,
-            CENTER_LOCATION.longitude
-          )
-        );
+        dustInfoMarkers.push(marker);
       });
     });
   }, [airQuality, allLocation]);
+
+  useEffect(() => {
+    kakao.maps.load(() => {
+      if (!map) return;
+      if (!dustInfoMarkers.length) return;
+
+      dustInfoMarkers.forEach((marker) => {
+        marker.setMap(map);
+      });
+
+      map.setCenter(
+        new kakao.maps.LatLng(
+          CENTER_LOCATION.latitude,
+          CENTER_LOCATION.longitude
+        )
+      );
+    });
+
+    return () => {
+      dustInfoMarkers.forEach((marker) => {
+        marker.setMap(null);
+      });
+    };
+  }, [dustInfoMarkers]);
 
   const handleCurrentLocationChange = () => {
     kakao.maps.load(() => {


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #33 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- [x] 전국 지도 모드일 때 지역별 마커가 계속 생성 및 추가되는 문제 해결



## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
- 문제 상황

https://user-images.githubusercontent.com/76807107/230946979-c438f8be-1970-4db1-8623-ffec3dd47f15.mp4

- 문제 해결

https://user-images.githubusercontent.com/76807107/230947080-67296b01-6c8c-4b40-917d-cef4993c84e4.mp4


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- useEffect를 하나의 컴포넌트에서 너무 많이 사용하고 있는데 어떻게 리팩토링하면 좋을까요...?
- 여러 마커를 한 번에 띄워야 하기 때문에 커스텀 오버레이 타입을 가진 배열에 마커들을 push한 후, 하나씩 순회하면서 지도에 마커를 띄우도록 했어요.
- 그리고 재생성되지 않도록 useEffect 훅의 cleanUp 함수를 사용해 언마운트될 때 마커를 제거했어요.
- 동영상처럼 airQuality API에서 NaN값이 반환되는 경우가 가끔 있는데 추후에 개선할게요. [이전 pr 리뷰 참고](https://github.com/tooooo1/dust-rating/pull/32#discussion_r1161468440)

## 질문 <!-- 궁금한 부분을 적어주세요 -->
- 이렇게 하는 게 맞는 건지.... 맞나요오오오오...?! 잘하고 있는 건가요...