### PR TITLE
fix: air quality API의 NaN 반환값 없애기

### DIFF
--- a/src/api/airQuality.ts
+++ b/src/api/airQuality.ts
@@ -5,23 +5,33 @@ const { VITE_AIR_QUALITY_URL, VITE_AIR_QUALITY_API_KEY } = import.meta.env;
 
 export const getAirQuality = async () => {
   try {
-    const result = await Promise.all(
-      CITY_GROUP.map((city) =>
-        axios
-          .get(
-            `${VITE_AIR_QUALITY_URL}?sidoName=${city.cityName}&pageNo=1&numOfRows=100&returnType=json&serviceKey=${VITE_AIR_QUALITY_API_KEY}&ver=1.0`
-          )
-          .then((res) => {
-            return res.data.response.body;
-          })
-      )
-    );
+    return await Promise.all(
+      CITY_GROUP.map(async (city) => {
+        const response = await axios.get(
+          `${VITE_AIR_QUALITY_URL}?sidoName=${city.cityName}&pageNo=1&numOfRows=100&returnType=json&serviceKey=${VITE_AIR_QUALITY_API_KEY}&ver=1.0`
+        );
 
-    return CITY_GROUP.map((city) => ({
-      cityName: city.cityName,
-      fineDustScale: Number(result[city.cityNumber]?.items[3]?.pm10Value),
-      ultraFineDustScale: Number(result[city.cityNumber]?.items[3]?.pm25Value),
-    }));
+        let fineDustScale = 0;
+        let ultraFineDustScale = 0;
+
+        for (const airQuality of response.data.response.body.items) {
+          if (airQuality.pm10Flag !== null || airQuality.pm25Flag !== null) {
+            continue;
+          }
+
+          fineDustScale = Number(airQuality.pm10Value);
+          ultraFineDustScale = Number(airQuality.pm25Value);
+
+          break;
+        }
+
+        return {
+          cityName: city.cityName,
+          fineDustScale,
+          ultraFineDustScale,
+        };
+      })
+    );
   } catch (error) {
     console.error(error);
   }

--- a/src/api/airQuality.ts
+++ b/src/api/airQuality.ts
@@ -11,6 +11,10 @@ export const getAirQuality = async () => {
           `${VITE_AIR_QUALITY_URL}?sidoName=${city.cityName}&pageNo=1&numOfRows=100&returnType=json&serviceKey=${VITE_AIR_QUALITY_API_KEY}&ver=1.0`
         );
 
+        if (response.status !== 200) {
+          throw new Error('API 에러');
+        }
+
         let fineDustScale = 0;
         let ultraFineDustScale = 0;
 

--- a/src/api/airQuality.ts
+++ b/src/api/airQuality.ts
@@ -19,7 +19,7 @@ export const getAirQuality = async () => {
         let ultraFineDustScale = 0;
 
         for (const airQuality of response.data.response.body.items) {
-          if (airQuality.pm10Flag === null && airQuality.pm25Flag === null) {
+          if (!airQuality.pm10Flag && !airQuality.pm25Flag) {
             fineDustScale = Number(airQuality.pm10Value);
             ultraFineDustScale = Number(airQuality.pm25Value);
 

--- a/src/api/airQuality.ts
+++ b/src/api/airQuality.ts
@@ -3,6 +3,13 @@ import { CITY_GROUP } from '@/utils/constants';
 
 const { VITE_AIR_QUALITY_URL, VITE_AIR_QUALITY_API_KEY } = import.meta.env;
 
+type Flag = null | '통신장애';
+
+interface AirQuality {
+  pm10Flag: Flag;
+  pm25Flag: Flag;
+}
+
 export const getAirQuality = async () => {
   try {
     return await Promise.all(
@@ -15,22 +22,14 @@ export const getAirQuality = async () => {
           throw new Error('API 에러');
         }
 
-        let fineDustScale = 0;
-        let ultraFineDustScale = 0;
-
-        for (const airQuality of response.data.response.body.items) {
-          if (!airQuality.pm10Flag && !airQuality.pm25Flag) {
-            fineDustScale = Number(airQuality.pm10Value);
-            ultraFineDustScale = Number(airQuality.pm25Value);
-
-            break;
-          }
-        }
+        const airQuality = response.data.response.body.items.filter(
+          ({ pm10Flag, pm25Flag }: AirQuality) => !pm10Flag && !pm25Flag
+        )[0];
 
         return {
           cityName: city.cityName,
-          fineDustScale,
-          ultraFineDustScale,
+          fineDustScale: Number(airQuality.pm10Value),
+          ultraFineDustScale: Number(airQuality.pm25Value),
         };
       })
     );

--- a/src/api/airQuality.ts
+++ b/src/api/airQuality.ts
@@ -19,14 +19,12 @@ export const getAirQuality = async () => {
         let ultraFineDustScale = 0;
 
         for (const airQuality of response.data.response.body.items) {
-          if (airQuality.pm10Flag !== null || airQuality.pm25Flag !== null) {
-            continue;
+          if (airQuality.pm10Flag === null && airQuality.pm25Flag === null) {
+            fineDustScale = Number(airQuality.pm10Value);
+            ultraFineDustScale = Number(airQuality.pm25Value);
+
+            break;
           }
-
-          fineDustScale = Number(airQuality.pm10Value);
-          ultraFineDustScale = Number(airQuality.pm25Value);
-
-          break;
         }
 
         return {

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -109,32 +109,20 @@ const Map = () => {
 
         dustInfoMarkers.push(marker);
       });
-    });
-  }, [airQuality, allLocation]);
-
-  useEffect(() => {
-    kakao.maps.load(() => {
-      if (!map) return;
-      if (!dustInfoMarkers.length) return;
 
       dustInfoMarkers.forEach((marker) => {
         marker.setMap(map);
       });
-
-      map.setCenter(
-        new kakao.maps.LatLng(
-          CENTER_LOCATION.latitude,
-          CENTER_LOCATION.longitude
-        )
-      );
     });
 
     return () => {
-      dustInfoMarkers.forEach((marker) => {
-        marker.setMap(null);
-      });
+      if (map && dustInfoMarkers.length) {
+        dustInfoMarkers.forEach((marker) => {
+          marker.setMap(null);
+        });
+      }
     };
-  }, [dustInfoMarkers]);
+  }, [airQuality, allLocation, dustInfoMarkers]);
 
   const handleCurrentLocationChange = () => {
     kakao.maps.load(() => {
@@ -169,6 +157,12 @@ const Map = () => {
       if (!map) return;
 
       map.setLevel(MAX_ZOOM_LEVEL, { animate: true });
+      map.setCenter(
+        new kakao.maps.LatLng(
+          CENTER_LOCATION.latitude,
+          CENTER_LOCATION.longitude
+        )
+      );
     });
   };
 

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -13,8 +13,8 @@ declare global {
   }
 }
 
-const MAX_ZOOM_LEVEL = 13;
 const INIT_ZOOM_LEVEL = 5;
+const MAX_ZOOM_LEVEL = 13;
 
 const Map = () => {
   const mapRef = useRef<HTMLDivElement>(null);
@@ -128,6 +128,7 @@ const Map = () => {
     kakao.maps.load(() => {
       if (!map) return;
 
+      map.setLevel(INIT_ZOOM_LEVEL, { animate: true });
       map.setCenter(
         new kakao.maps.LatLng(location.latitude, location.longitude)
       );


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #36

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- [x] air quality API [유효한 값 반환하도록 수정](https://github.com/tooooo1/dust-rating/commit/52b00d2c7e6e9c962bc8eb56a68f2eb5fd232eda)
- [x] [마커 중복 생성 해결](https://github.com/tooooo1/dust-rating/commit/8877e5306cafd0b08c3605d963bd03bf330b1d45)

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://user-images.githubusercontent.com/76807107/231429836-4ee77ee5-a387-4ba3-80d9-5ef04dc6470b.png)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 제 생각에 가장 최신의 수치 데이터를 보여주기 위해서 마커는 항상 삭제된 다음에 새로운 마커로 대체되어야 한다고 생각했어요. 그런데 마커가 중복 생성되는 문제가 있었고 이 문제를 이전 pr에서 해결했다고 생각했는데 지도가 확대될 때 마커가 보이지 않는 문제가 있었어요. 
- 커스텀오버레이로 마커를 생성하고 위치시키는 로직을 분리하지 않고 하나로 합쳐서 그 문제를 해결할 수 있었어요.
- air quality API가 유효하지 않은 값을 반환하는 경우가 있었는데, 이는 각 지역의 수치 배열을 순회하면서 해당 수치값의 flag 값을 확인해 유효한 값만 반환하도록 수정했어요.

![image](https://user-images.githubusercontent.com/76807107/231437892-aa1194a9-c054-4b24-ae51-215faa369865.png)


## 질문 <!-- 궁금한 부분을 적어주세요 -->
.