### PR TITLE
Refactor: 미세먼지 순서로 정렬되도록 변경

### DIFF
--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -62,7 +62,7 @@ const Result = () => {
     target.value === FINE_DUST ? setSelectedDust(FINE_DUST) : setSelectedDust(ULTRA_FINE_DUST);    
   };
 
-  const sortCityDust = (cityGroup: CityGroup[]) => {
+  const sortCityByDustDensity = (cityGroup: CityGroup[]) => {
     if (!sidoDust) return [];
 
     return cityGroup.sort((prev, next) => {
@@ -118,7 +118,7 @@ const Result = () => {
               {ULTRA_FINE_DUST}
             </option>
           </Select>
-          {sortCityDust(cityGroup).map((city, cityIdx) => {
+          {sortCityByDustDensity(cityGroup).map((city, cityIdx) => {
             return (
               <Rank
                 key={city.cityName}

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -68,17 +68,13 @@ const Result = () => {
     return cityGroup.sort((prev, next) => {
       const prevCity = sidoDust[prev.cityNumber]?.items[4];
       const nextCity = sidoDust[next.cityNumber]?.items[4];
-      if (selectedDust === FINE_DUST) {
-        const prevCityFineDust = +prevCity.pm10Value;
-        const nextCityFineDust = +nextCity.pm10Value;
-        if (prevCityFineDust < nextCityFineDust) return -1;
-        else if (prevCityFineDust > nextCityFineDust) return 1;
+      if (selectedDust === FINE_DUST) {        
+        if (+prevCity.pm10Value < +nextCity.pm10Value) return -1;
+        else if (+prevCity.pm10Value > +nextCity.pm10Value) return 1;
         else return 0;
-      } else if (selectedDust === ULTRA_FINE_DUST) {
-        const prevCityUltraFineDust = +prevCity.pm25Value;
-        const nextCityUltraFineDust = +nextCity.pm25Value;
-        if (prevCityUltraFineDust < nextCityUltraFineDust) return -1;
-        else if (prevCityUltraFineDust > nextCityUltraFineDust) return 1;
+      } else if (selectedDust === ULTRA_FINE_DUST) {        
+        if (+prevCity.pm25Value< +nextCity.pm25Value) return -1;
+        else if (+prevCity.pm25Value > +nextCity.pm25Value) return 1;
         else return 0;
       }
       return 0;

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -79,23 +79,36 @@ const Result = () => {
       <Rating>
         <RatingWidth>
           <DustRating>지역별 {FINE_DUST} 농도 순위</DustRating>
-          {cityGroup.map((city) => {
-            return (
-              <Rank
-                key={city.cityName}
-                rank={city.cityNumber + 1}
-                city={city.cityName}
-                dust={sidoDust[city.cityNumber]?.items[4]?.pm10Value}
-                ultraDust={sidoDust[city.cityNumber]?.items[4]?.pm25Value}
-                dustState={(
-                  (parseInt(sidoDust[city.cityNumber]?.items[4]?.pm10Grade) +
-                    parseInt(sidoDust[city.cityNumber]?.items[4]?.pm25Grade)) /
-                  2
-                ).toString()}
-                detail={sidoDust[city.cityNumber]?.items}
-              />
-            );
-          })}
+          {cityGroup
+            .sort((prevCity, nextCity) => {
+              const prevCityFineDust =
+                sidoDust[prevCity.cityNumber]?.items[4]?.pm10Value;
+              const nextCityFineDust =
+                sidoDust[nextCity.cityNumber]?.items[4]?.pm10Value;
+
+              if (prevCityFineDust < nextCityFineDust) return -1;
+              else if (prevCityFineDust > nextCityFineDust) return 1;
+              else return 0;
+            })
+            .map((city, cityIdx) => {
+              return (
+                <Rank
+                  key={city.cityName}
+                  rank={cityIdx + 1}
+                  city={city.cityName}
+                  dust={sidoDust[city.cityNumber]?.items[4]?.pm10Value}
+                  ultraDust={sidoDust[city.cityNumber]?.items[4]?.pm25Value}
+                  dustState={(
+                    (parseInt(sidoDust[city.cityNumber]?.items[4]?.pm10Grade) +
+                      parseInt(
+                        sidoDust[city.cityNumber]?.items[4]?.pm25Grade
+                      )) /
+                    2
+                  ).toString()}
+                  detail={sidoDust[city.cityNumber]?.items}
+                />
+              );
+            })}
         </RatingWidth>
       </Rating>
     </Mid>

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -4,7 +4,7 @@ import { DustState } from '../components/Dust';
 import Progress from '../components/Progress';
 import Rank from '../components/Rank';
 import useFetchDustInfo, { cityGroup } from '../hooks/useFetchDustInfo';
-import { type SidoDust type CityGroup } from '@/type';
+import type { SidoDust, CityGroup } from '@/type';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
 import { useQuery } from '@tanstack/react-query';
 import { Select } from '@chakra-ui/react';
@@ -59,7 +59,9 @@ const Result = () => {
 
   const handleDustChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const { target } = e;
-    target.value === FINE_DUST ? setSelectedDust(FINE_DUST) : setSelectedDust(ULTRA_FINE_DUST);    
+    target.value === FINE_DUST
+      ? setSelectedDust(FINE_DUST)
+      : setSelectedDust(ULTRA_FINE_DUST);
   };
 
   const sortCityByDustDensity = (cityGroup: CityGroup[]) => {
@@ -68,12 +70,12 @@ const Result = () => {
     return cityGroup.sort((prev, next) => {
       const prevCity = sidoDust[prev.cityNumber]?.items[4];
       const nextCity = sidoDust[next.cityNumber]?.items[4];
-      if (selectedDust === FINE_DUST) {        
+      if (selectedDust === FINE_DUST) {
         if (+prevCity.pm10Value < +nextCity.pm10Value) return -1;
         else if (+prevCity.pm10Value > +nextCity.pm10Value) return 1;
         else return 0;
-      } else if (selectedDust === ULTRA_FINE_DUST) {        
-        if (+prevCity.pm25Value< +nextCity.pm25Value) return -1;
+      } else if (selectedDust === ULTRA_FINE_DUST) {
+        if (+prevCity.pm25Value < +nextCity.pm25Value) return -1;
         else if (+prevCity.pm25Value > +nextCity.pm25Value) return 1;
         else return 0;
       }

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -4,12 +4,11 @@ import { DustState } from '../components/Dust';
 import Progress from '../components/Progress';
 import Rank from '../components/Rank';
 import useFetchDustInfo, { cityGroup } from '../hooks/useFetchDustInfo';
-import { type SidoDust } from '@/type';
+import { type SidoDust type CityGroup } from '@/type';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
 import { useQuery } from '@tanstack/react-query';
 import { Select } from '@chakra-ui/react';
 import { ChangeEvent, useState } from 'react';
-import { CityGroup } from '@/type';
 
 const Result = () => {
   const [selectedDust, setSelectedDust] = useState(FINE_DUST);
@@ -60,8 +59,7 @@ const Result = () => {
 
   const handleDustChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const { target } = e;
-    if (target.value === FINE_DUST) setSelectedDust(FINE_DUST);
-    else if (target.value === ULTRA_FINE_DUST) setSelectedDust(ULTRA_FINE_DUST);
+    target.value === FINE_DUST ? setSelectedDust(FINE_DUST) : setSelectedDust(ULTRA_FINE_DUST);    
   };
 
   const sortCityDust = (cityGroup: CityGroup[]) => {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -27,3 +27,8 @@ export interface Location {
   latitude: number;
   longitude: number;
 }
+
+export interface CityGroup {
+  cityName: string;
+  cityNumber: number;
+}


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #12

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
result Page에서 [미세먼지 | 초미세먼지] 오름차순으로 정렬할 수 있습니다.
![image](https://user-images.githubusercontent.com/12118892/231973801-d0d02749-db8a-4323-a84b-6dd20e3659ae.png)


## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
움짤에는 option 태그들이 안보이네요
![chrome-capture-2023-3-14](https://user-images.githubusercontent.com/12118892/231975493-1b8260cd-62b1-442d-bee1-9502c3f265e2.gif)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
1. sortCityDust라는 함수가 있는데 page를 구성하는 파일에 남겨둬도 될까? 하는 생각이 들어요.
2. selectedDust라는 state를 사용해서 선택된 [미세먼지 | 초미세먼지]를 파악하도록 했는데 더 좋은 방법이 있다면 알려주세요!
## 질문 <!-- 궁금한 부분을 적어주세요 -->
1. option의 style을 적용하는 부분에서 ```import styled from '@emotion/styled';```을 활용해서 style을 적용하려고 하면 적용되지 않아서 tsx에 일일히 따로 적용했는데 정확한 이유를 모르겠어요. Chakra UI 문서나 chatGPT에서 알려준 방법들 중에서도 적당한 방법이 없는것 같아서 질문드려요!

```
<option style={{ backgroundColor: '#44b7f7', color: '#ffffff' }}>
          {FINE_DUST}
</option>
<option style={{ backgroundColor: '#44b7f7', color: '#ffffff' }}>
          {ULTRA_FINE_DUST}
</option>
```
2. 먼지 농도순으로 정렬된 결과를 보여주는 부분에서 ```sortCityDust(cityGroup).map((city, cityIdx)``` 가 사용되요. 여기서 sorting을 진행하는 부분과 map메서드가  성격이 다르다고 생각해서 sort 부분만 함수로 분리했는데 map 까지 묶어서 함수로 분리하는 것이 가독성이나 이해하는 측면에서 더 괜찮을까요?