### PR TITLE
feat: 마커 내부에 지역명 정보 추가하기

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -98,8 +98,12 @@ const Map = () => {
 
         const template = `
           <div class="dust-info-marker" style="background-color: ${backgroundColor};">
-            <span>${fineDustScale}/${ultraFineDustScale}</span>
             <p class="city-name">${cityName}</p>
+            <div class="dust-info">
+              <div>${fineDustScale}</div>
+              <span class="divider">&sol;</span>
+              <div>${ultraFineDustScale}</div>  
+            </div>
           </div>`;
 
         const marker = new kakao.maps.CustomOverlay({

--- a/src/styles/globalStyle.css
+++ b/src/styles/globalStyle.css
@@ -40,37 +40,28 @@
 }
 
 .dust-info-marker {
-  position: relative;
-  top: -2.2rem;
-  min-width: 2rem;
-  padding: 0.8rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.6rem 0.8rem;
   color: #ffffff;
-  background-color: #e64746;
-  border: 0.2rem solid #ffffff;
+  border: 0.18rem solid #ffffff;
   border-radius: 2rem;
 }
 
-.dust-info-marker::before {
-  content: '';
-  position: absolute;
-  bottom: -0.8rem;
-  left: 50%;
-  width: 0;
-  height: 0;
-  border-width: 0.7rem 0.6rem 0;
-  border-style: solid;
-  border-color: transparent;
-  border-top-color: inherit;
-  -webkit-transform: translateX(-50%);
-  transform: translateX(-50%);
+.dust-info {
+  display: flex;
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+.divider {
+  padding: 0 0.05rem 0 0.08rem;
 }
 
 .city-name {
-  position: absolute;
-  left: 50%;
-  bottom: -2.2rem;
+  font-size: 0.8rem;
   font-weight: 700;
+  margin-bottom: 0.2rem;
   color: #2a282f;
-  -webkit-transform: translateX(-50%);
-  transform: translateX(-50%);
 }


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #47 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- [x] 마커 내부에 지역명 정보 추가하기

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://user-images.githubusercontent.com/76807107/232719982-5abf8527-c975-40d9-90cc-1c0fe1a3d714.png)


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 기존에 지도와 마커의 정보가 겹치는 문제가 있어 지역명을 마커 내부로 위치키도록 했어요.
![image](https://user-images.githubusercontent.com/76807107/232720261-11b34f5b-4c07-42d4-9d82-39f535c41b95.png)
- 하나의 마커에 너무 많은 정보가 들어갈 것 같아 미세먼지 수치 정보인지 초미세먼지 수치 정보인지는 따로 표기하지 않았어요. 추후에 지도의 하단 부분에 마커의 정보 구성?을 표시하면 좋을 것 같아요.

## 질문 <!-- 궁금한 부분을 적어주세요 -->
.