### PR TITLE
refactor: Ranking 페이지 chakra-ui 적용하기

### DIFF
--- a/src/components/Dust/DustState.tsx
+++ b/src/components/Dust/DustState.tsx
@@ -1,5 +1,5 @@
+import { Box, Flex } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-import { Box } from '@chakra-ui/react';
 import {
   BsEmojiHeartEyes,
   BsEmojiNeutral,
@@ -49,13 +49,13 @@ const DustState = ({ fineDust, ultraFineDust, kindOfDust }: DustStateProps) => {
 
   return (
     <DustStateColor color={DUST_RATE_COLOR[discriminateDust()]}>
-      <Box fontSize={`1.5vh`}>{`${
+      <Box fontSize={3}>{`${
         kindOfDust === 'avg' ? `` : `${fineDust}㎍/㎥`
       }`}</Box>
-      <Box display={'flex'} flexDirection={'column'} justifyContent={'center'}>
-        {DUST_ICON[discriminateDust()]}
-        {DUST_RATE[discriminateDust()]}
-      </Box>
+      <Flex direction="column" alignItems="center">
+        <div>{DUST_ICON[discriminateDust()]}</div>
+        <div>{DUST_RATE[discriminateDust()]}</div>
+      </Flex>
     </DustStateColor>
   );
 };
@@ -63,12 +63,11 @@ const DustState = ({ fineDust, ultraFineDust, kindOfDust }: DustStateProps) => {
 export default DustState;
 
 const DustStateColor = styled.div`
-  font-size: 5.5vw;
   display: flex;
   justify-content: center;
+  width: 40%;
+  font-size: 1.4rem;
+  text-align: center;
   font-weight: 700;
   color: ${(props) => props.color};
-  @media only screen and (min-width: 768px) {
-    font-size: 25px;
-  }
 `;

--- a/src/components/Dust/DustState.tsx
+++ b/src/components/Dust/DustState.tsx
@@ -65,7 +65,8 @@ export default DustState;
 const DustStateColor = styled.div`
   display: flex;
   justify-content: center;
-  width: 40%;
+  width: 36%;
+  margin-right: 1rem;
   font-size: 1.4rem;
   text-align: center;
   font-weight: 700;

--- a/src/components/Dust/DustState.tsx
+++ b/src/components/Dust/DustState.tsx
@@ -53,8 +53,8 @@ const DustState = ({ fineDust, ultraFineDust, kindOfDust }: DustStateProps) => {
         kindOfDust === 'avg' ? `` : `${fineDust}㎍/㎥`
       }`}</Box>
       <Flex direction="column" alignItems="center">
-        <div>{DUST_ICON[discriminateDust()]}</div>
-        <div>{DUST_RATE[discriminateDust()]}</div>
+        <Box>{DUST_ICON[discriminateDust()]}</Box>
+        <Box>{DUST_RATE[discriminateDust()]}</Box>
       </Flex>
     </DustStateColor>
   );

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,14 +1,20 @@
 import { Outlet } from 'react-router-dom';
+import { Image } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 
 const Logo = () => (
   <>
-    <Img
-      onClick={() => window.open('https://tooo1.tistory.com')}
+    <Image
       src="images/il.jpg"
       alt="il"
+      position="absolute"
+      top={4}
+      left={4}
       width={50}
       height={50}
+      borderRadius="50%"
+      cursor="pointer"
+      onClick={() => window.open('https://tooo1.tistory.com')}
     />
     <Main>
       <Outlet />
@@ -17,15 +23,6 @@ const Logo = () => (
 );
 
 export default Logo;
-
-export const Img = styled.img`
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 1;
-  border-radius: 100px;
-  cursor: pointer;
-`;
 
 export const Main = styled.main`
   width: 37.5rem;

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -28,9 +28,7 @@ export const Img = styled.img`
 `;
 
 export const Main = styled.main`
-  @media screen and (min-width: 768px) {
-    width: 37.5rem;
-  }
+  width: 37.5rem;
   @media screen and (max-width: 767px) {
     width: 100%;
   }

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -10,9 +10,9 @@ const Logo = () => (
       width={50}
       height={50}
     />
-    <main>
+    <Main>
       <Outlet />
-    </main>
+    </Main>
   </>
 );
 
@@ -25,4 +25,13 @@ export const Img = styled.img`
   z-index: 1;
   border-radius: 100px;
   cursor: pointer;
+`;
+
+export const Main = styled.main`
+  @media screen and (min-width: 768px) {
+    width: 37.5rem;
+  }
+  @media screen and (max-width: 767px) {
+    width: 100%;
+  }
 `;

--- a/src/components/Ranking/CityRank.tsx
+++ b/src/components/Ranking/CityRank.tsx
@@ -20,58 +20,83 @@ const CityRank = ({ sido, isShow }: CityRankProps) => {
   );
 
   return (
-    <>
+    <Box
+      width="98%"
+      margin="0 auto"
+      bg="#dfdfdf"
+      borderRadius={10}
+      px={4}
+      cursor="pointer"
+    >
       {isShow &&
         cityAirQualities &&
         cityAirQualities.map((city, cityIndex) => (
-          <Box
+          <Flex
             key={city.cityName}
-            width="95%"
-            margin="0 auto"
-            borderRadius={10}
+            justifyContent="space-between"
+            alignItems="center"
             py={3}
-            cursor="pointer"
           >
-            <Flex justifyContent="space-between" alignItems="center">
-              <Text
-                as="span"
-                width="10%"
-                fontSize={18}
-                fontWeight={400}
-                color="#9dadb6"
-              >
-                {cityIndex + 1}
-              </Text>
-              <Text as="p" width="26%" fontSize={24} fontWeight={500}>
-                {city.cityName}
-              </Text>
-              <DustState
-                fineDust={city.fineDustGrade}
-                ultraFineDust={city.ultraFineDustGrade}
-                kindOfDust="avg"
-              />
-              <Flex direction="column" justifyContent="center" flexGrow={1}>
-                <Flex justifyContent="space-between" py={1}>
-                  <Text as="p" fontSize={16} fontWeight={400}>
-                    {FINE_DUST}
-                  </Text>
-                  <Text as="p" fontSize={16} fontWeight={600}>
-                    {city.fineDustScale}
-                  </Text>
-                </Flex>
-                <Flex justifyContent="space-between" py={1}>
-                  <Text as="p" fontSize={16} fontWeight={400}>
-                    {ULTRA_FINE_DUST}
-                  </Text>
-                  <Text as="p" fontSize={16} fontWeight={600}>
-                    {city.ultraFineDustScale}
-                  </Text>
-                </Flex>
+            <Text
+              as="span"
+              fontSize={18}
+              fontWeight={400}
+              mr={4}
+              color="#9dadb6"
+            >
+              {cityIndex + 1}
+            </Text>
+            <Text
+              as="p"
+              width="30%"
+              fontSize={24}
+              fontWeight={500}
+              overflow="hidden"
+              whiteSpace="nowrap"
+              textOverflow="ellipsis"
+            >
+              {city.cityName}
+            </Text>
+            <DustState
+              fineDust={city.fineDustGrade}
+              ultraFineDust={city.ultraFineDustGrade}
+              kindOfDust="avg"
+            />
+            <Flex direction="column" justifyContent="center" flexGrow={1}>
+              <Flex justifyContent="space-between" py={1}>
+                <Text
+                  as="p"
+                  fontSize={16}
+                  fontWeight={400}
+                  overflow="hidden"
+                  whiteSpace="nowrap"
+                  textOverflow="ellipsis"
+                >
+                  {FINE_DUST}
+                </Text>
+                <Text as="p" fontSize={16} fontWeight={600}>
+                  {city.fineDustScale}
+                </Text>
+              </Flex>
+              <Flex justifyContent="space-between" py={1}>
+                <Text
+                  as="p"
+                  fontSize={16}
+                  fontWeight={400}
+                  overflow="hidden"
+                  whiteSpace="nowrap"
+                  textOverflow="ellipsis"
+                >
+                  {ULTRA_FINE_DUST}
+                </Text>
+                <Text as="p" fontSize={16} fontWeight={600}>
+                  {city.ultraFineDustScale}
+                </Text>
               </Flex>
             </Flex>
-          </Box>
+          </Flex>
         ))}
-    </>
+    </Box>
   );
 };
 

--- a/src/components/Ranking/CityRank.tsx
+++ b/src/components/Ranking/CityRank.tsx
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
+import { Box, Flex, Text } from '@chakra-ui/react';
 import { DustState } from '@/components/Dust';
 import { getCityAirQualities } from '@/api/airQuality';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
 import type { CityAirQuality } from '@/type';
-import styled from '@emotion/styled';
 
 interface CityRankProps {
   sido: string;
@@ -24,125 +24,55 @@ const CityRank = ({ sido, isShow }: CityRankProps) => {
       {isShow &&
         cityAirQualities &&
         cityAirQualities.map((city, cityIndex) => (
-          <RatingWrapper key={city.cityName}>
-            <Top>
-              <RatingDetails>
-                <Rank>{cityIndex + 1}</Rank>
-                <RankLocation>{city.cityName}</RankLocation>
-                <DustStateWrapper>
-                  <DustState
-                    fineDust={city.fineDustGrade}
-                    ultraFineDust={city.ultraFineDustGrade}
-                    kindOfDust="avg"
-                  />
-                </DustStateWrapper>
-              </RatingDetails>
-              <DustWrapper>
-                <DustWrapperFlex>
-                  <div>{FINE_DUST}</div>
-                  <DustFigure>{city.fineDustScale}</DustFigure>
-                </DustWrapperFlex>
-                <DustWrapperFlex>
-                  <div>{ULTRA_FINE_DUST}</div>
-                  <DustFigure>{city.ultraFineDustScale}</DustFigure>
-                </DustWrapperFlex>
-              </DustWrapper>
-            </Top>
-          </RatingWrapper>
+          <Box
+            key={city.cityName}
+            width="95%"
+            margin="0 auto"
+            borderRadius={10}
+            py={3}
+            cursor="pointer"
+          >
+            <Flex justifyContent="space-between" alignItems="center">
+              <Text
+                as="span"
+                width="10%"
+                fontSize={18}
+                fontWeight={400}
+                color="#9dadb6"
+              >
+                {cityIndex + 1}
+              </Text>
+              <Text as="p" width="26%" fontSize={24} fontWeight={500}>
+                {city.cityName}
+              </Text>
+              <DustState
+                fineDust={city.fineDustGrade}
+                ultraFineDust={city.ultraFineDustGrade}
+                kindOfDust="avg"
+              />
+              <Flex direction="column" justifyContent="center" flexGrow={1}>
+                <Flex justifyContent="space-between" py={1}>
+                  <Text as="p" fontSize={16} fontWeight={400}>
+                    {FINE_DUST}
+                  </Text>
+                  <Text as="p" fontSize={16} fontWeight={600}>
+                    {city.fineDustScale}
+                  </Text>
+                </Flex>
+                <Flex justifyContent="space-between" py={1}>
+                  <Text as="p" fontSize={16} fontWeight={400}>
+                    {ULTRA_FINE_DUST}
+                  </Text>
+                  <Text as="p" fontSize={16} fontWeight={600}>
+                    {city.ultraFineDustScale}
+                  </Text>
+                </Flex>
+              </Flex>
+            </Flex>
+          </Box>
         ))}
     </>
   );
 };
 
 export default CityRank;
-
-const RatingWrapper = styled.div`
-  position: relative;
-  flex-direction: column;
-  cursor: pointer;
-  display: flex;
-  justify-content: center;
-  font-size: 3vh;
-  text-align: center;
-  border-bottom: 1px solid #dfdfdf;
-  border-radius: 10px;
-  padding: 1vh 0;
-  width: 90%;
-  margin: 0 auto;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-  transform: height 0.35s ease;
-`;
-
-const RatingDetails = styled.div`
-  width: 68%;
-  display: flex;
-  justify-content: space-between;
-  text-align: center;
-  align-items: center;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-`;
-
-const Rank = styled.div`
-  width: 10%;
-  display: flex;
-  font-size: 2vh;
-  font-weight: 600;
-  color: #9dadb6;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-`;
-
-const RankLocation = styled.div`
-  display: flex;
-  font-weight: 600;
-  font-size: 5.5vw;
-  @media only screen and (min-width: 768px) {
-    font-size: 25px;
-  }
-`;
-
-const DustStateWrapper = styled.div`
-  width: 50%;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-`;
-
-const DustWrapper = styled.div`
-  width: 32%;
-  font-weight: 300;
-  font-size: 3.3vw;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-`;
-
-const DustWrapperFlex = styled.div`
-  display: flex;
-  font-weight: 300;
-  justify-content: space-between;
-  margin: 0.5rem 0;
-  @media only screen and (min-width: 768px) {
-    font-size: 18px;
-  }
-`;
-
-const DustFigure = styled.div`
-  display: flex;
-  margin-left: 2vw;
-  font-weight: 600;
-  @media only screen and (min-width: 768px) {
-    font-size: 18px;
-    margin-left: 10px;
-  }
-`;
-
-const Top = styled.div`
-  display: flex;
-  width: 100%;
-`;

--- a/src/components/Ranking/SidoRank.tsx
+++ b/src/components/Ranking/SidoRank.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
+import { Box, Flex, Text } from '@chakra-ui/react';
 import { DustState } from '@/components/Dust';
 import CityRank from './CityRank';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
-import styled from '@emotion/styled';
 
 interface SidoRankProps {
   rank: number;
@@ -28,136 +28,56 @@ const SidoRank = ({
   };
 
   return (
-    <RatingWrapper key={sidoName} onClick={handleSidoClick}>
-      <Top>
-        <RatingDetails>
-          <RankW>{rank}</RankW>
-          <RankLocation>{sidoName}</RankLocation>
-          <DustStateW>
-            <DustState
-              fineDust={fineDustGrade}
-              ultraFineDust={ultraFineDustGrade}
-              kindOfDust="avg"
-            />
-          </DustStateW>
-        </RatingDetails>
-        <DustWrapper>
-          <DustWrapperFlex>
-            <div>{FINE_DUST}</div>
-            <DustFigure>{fineDustScale}</DustFigure>
-          </DustWrapperFlex>
-          <DustWrapperFlex>
-            <div>{ULTRA_FINE_DUST}</div>
-            <DustFigure>{ultraFineDustScale}</DustFigure>
-          </DustWrapperFlex>
-        </DustWrapper>
-      </Top>
-      <Container>
-        <CityRank sido={sidoName} isShow={isShow} />
-      </Container>
-    </RatingWrapper>
+    <Box
+      width="100%"
+      borderRadius={10}
+      py={3}
+      borderBottom="1px solid #dfdfdf"
+      transition="all 100ms ease-in"
+      cursor="pointer"
+      _hover={{ backgroundColor: '#dfdfdf', paddingX: '0.8rem', opacity: 0.8 }}
+      onClick={handleSidoClick}
+    >
+      <Flex alignItems="center">
+        <Text
+          as="span"
+          width="10%"
+          fontSize={20}
+          fontWeight={600}
+          color="#9dadb6"
+        >
+          {rank}
+        </Text>
+        <Text as="p" width="26%" fontSize={26} fontWeight={700}>
+          {sidoName}
+        </Text>
+        <DustState
+          fineDust={fineDustGrade}
+          ultraFineDust={ultraFineDustGrade}
+          kindOfDust="avg"
+        />
+        <Flex direction="column" justifyContent="center" flexGrow={1}>
+          <Flex justifyContent="space-between" py={1}>
+            <Text as="p" fontSize={16} fontWeight={500}>
+              {FINE_DUST}
+            </Text>
+            <Text as="p" fontSize={16} fontWeight={800}>
+              {fineDustScale}
+            </Text>
+          </Flex>
+          <Flex justifyContent="space-between" py={1}>
+            <Text as="p" fontSize={16} fontWeight={500}>
+              {ULTRA_FINE_DUST}
+            </Text>
+            <Text as="p" fontSize={16} fontWeight={800}>
+              {ultraFineDustScale}
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+      <CityRank sido={sidoName} isShow={isShow} />
+    </Box>
   );
 };
 
 export default SidoRank;
-
-const RatingWrapper = styled.div`
-  cursor: pointer;
-  display: flex;
-  justify-content: center;
-  font-size: 3vh;
-  text-align: center;
-  border-bottom: 1px solid #dfdfdf;
-  border-radius: 10px;
-  padding: 1vh 0;
-  flex-direction: column;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-  transition-duration: 0.3s;
-  &:hover {
-    background-color: #dfdfdf;
-    padding-left: 10px;
-    padding-right: 10px;
-    opacity: 0.8;
-  }
-`;
-
-const RatingDetails = styled.div`
-  width: 68%;
-  display: flex;
-  justify-content: space-between;
-  text-align: center;
-  align-items: center;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-`;
-
-const RankW = styled.div`
-  width: 10%;
-  display: flex;
-  font-size: 2vh;
-  color: #9dadb6;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-`;
-
-const RankLocation = styled.div`
-  display: flex;
-  font-size: 5.5vw;
-  @media only screen and (min-width: 768px) {
-    font-size: 25px;
-  }
-`;
-
-const DustStateW = styled.div`
-  width: 50%;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-`;
-
-const DustWrapper = styled.div`
-  width: 32%;
-  font-weight: 500;
-  font-size: 3.3vw;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-`;
-
-const DustWrapperFlex = styled.div`
-  display: flex;
-  font-weight: 500;
-  justify-content: space-between;
-  margin: 0.5rem 0;
-  @media only screen and (min-width: 768px) {
-    font-size: 18px;
-  }
-`;
-
-const DustFigure = styled.div`
-  display: flex;
-  margin-left: 2vw;
-  font-weight: 800;
-  @media only screen and (min-width: 768px) {
-    font-size: 18px;
-    margin-left: 10px;
-  }
-`;
-
-const Top = styled.div`
-  display: flex;
-  width: 100%;
-`;
-
-const Container = styled.div`
-  width: 100%;
-  background-color: #dfdfdf;
-  border-radius: 10px;
-  display: flex;
-  position: relative;
-  flex-direction: column;
-`;

--- a/src/components/Ranking/SidoRank.tsx
+++ b/src/components/Ranking/SidoRank.tsx
@@ -39,16 +39,18 @@ const SidoRank = ({
       onClick={handleSidoClick}
     >
       <Flex alignItems="center">
-        <Text
-          as="span"
-          width="10%"
-          fontSize={20}
-          fontWeight={600}
-          color="#9dadb6"
-        >
+        <Text as="span" fontSize={20} fontWeight={600} mr={4} color="#9dadb6">
           {rank}
         </Text>
-        <Text as="p" width="26%" fontSize={26} fontWeight={700}>
+        <Text
+          as="p"
+          width="30%"
+          fontSize={26}
+          fontWeight={700}
+          overflow="hidden"
+          whiteSpace="nowrap"
+          textOverflow="ellipsis"
+        >
           {sidoName}
         </Text>
         <DustState

--- a/src/pages/Choice.tsx
+++ b/src/pages/Choice.tsx
@@ -22,6 +22,7 @@ const Choice = () => {
 
   return (
     <Flex
+      height="100vh"
       direction="column"
       justify="center"
       align="center"

--- a/src/pages/DustMap.tsx
+++ b/src/pages/DustMap.tsx
@@ -12,7 +12,7 @@ const DustMapPage = () => {
 export default DustMapPage;
 
 const MapContainer = styled.div`
-  max-width: 520px;
+  max-width: 37.5rem;
   width: 100vw;
   height: 100vh;
 `;

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -1,13 +1,12 @@
 import { ChangeEvent, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Select } from '@chakra-ui/react';
+import { Flex, Box, Text, Center, Select } from '@chakra-ui/react';
 import { DustState } from '@/components/Dust';
 import ProgressBar from '@/components/ProgressBar';
 import SidoRank from '@/components/Ranking/SidoRank';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
 import { getSidoAirQualities, getSidoAirQuality } from '@/api/airQuality';
-import styled from '@emotion/styled';
 
 type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 
@@ -54,21 +53,49 @@ const Ranking = () => {
   };
 
   if (!sidoAirQuality) {
-    return <Time>로딩 중...</Time>;
+    return (
+      <Center height="100vh" fontSize={28} fontWeight={100} color="#ffffff">
+        로딩 중...
+      </Center>
+    );
   }
 
   return (
-    <Mid>
-      <State>전국 미세 먼지 농도는 다음과 같습니다</State>
-      <Time>{sidoAirQuality.dataTime} 기준</Time>
-      <Middle>
-        <Location>{selectedSido}</Location>
-        <Text>현재의 대기질 지수는</Text>
-        <DustState
-          fineDust={sidoAirQuality.fineDustGrade}
-          ultraFineDust={sidoAirQuality.ultraFineDustGrade}
-          kindOfDust="avg"
-        />
+    <Box textAlign="center">
+      <Text
+        as="h1"
+        fontSize={30}
+        fontWeight={600}
+        color="#ffffff"
+        mt={20}
+        mb={4}
+      >
+        전국 미세 먼지 농도는 다음과 같습니다
+      </Text>
+      <Text as="p" fontSize={20} fontWeight={300} color="#ffffff" mb={6}>
+        {sidoAirQuality.dataTime} 기준
+      </Text>
+      <Box
+        w="80%"
+        margin="0 auto"
+        borderTopRadius={10}
+        textAlign="center"
+        bg="#ffffff"
+        py={8}
+      >
+        <Text as="p" fontSize={30} fontWeight={700} mb={4}>
+          {selectedSido}
+        </Text>
+        <Text as="span" fontSize={18} color="#9dadb6">
+          현재의 대기질 지수는
+        </Text>
+        <Center my={5}>
+          <DustState
+            fineDust={sidoAirQuality.fineDustGrade}
+            ultraFineDust={sidoAirQuality.ultraFineDustGrade}
+            kindOfDust="avg"
+          />
+        </Center>
         <ProgressBar id="fineDust" state={sidoAirQuality.fineDustScale}>
           {FINE_DUST}
         </ProgressBar>
@@ -78,126 +105,54 @@ const Ranking = () => {
         >
           {ULTRA_FINE_DUST}
         </ProgressBar>
-      </Middle>
-      <Rating>
-        <RatingWidth>
-          <DustRating>지역별 미세 먼지 농도 순위</DustRating>
-          <Select bg="#44b7f7" color="#ffffff" onChange={handleSortKeyChange}>
-            <option style={{ backgroundColor: '#44b7f7', color: '#ffffff' }}>
-              {FINE_DUST}
-            </option>
-            <option style={{ backgroundColor: '#44b7f7', color: '#ffffff' }}>
-              {ULTRA_FINE_DUST}
-            </option>
-          </Select>
-          {sidoAirQualities?.map((sido, sidoIndex) => (
-            <SidoRank
-              key={sido.sidoName}
-              rank={sidoIndex + 1}
-              sidoName={sido.sidoName}
-              fineDustScale={sido.fineDustScale}
-              ultraFineDustScale={sido.ultraFineDustScale}
-              fineDustGrade={sido.fineDustGrade}
-              ultraFineDustGrade={sido.ultraFineDustGrade}
-            />
-          ))}
-        </RatingWidth>
-      </Rating>
-    </Mid>
+      </Box>
+      <Flex
+        direction="column"
+        justifyContent="center"
+        alignItems="center"
+        borderRadius={20}
+        bg="#f6f6f6"
+        mb={20}
+        px={20}
+        py={10}
+      >
+        <Text
+          as="p"
+          fontSize={20}
+          fontWeight={400}
+          margin="0 auto"
+          px={8}
+          py={3}
+          borderRadius={25}
+          color="#ffffff"
+          bg="#44b7f7"
+        >
+          지역별 미세 먼지 농도 순위
+        </Text>
+        <Select
+          color="#3a9cbd"
+          borderColor="#3a9cbd"
+          borderWidth={2}
+          my={4}
+          onChange={handleSortKeyChange}
+        >
+          <option>{FINE_DUST}</option>
+          <option>{ULTRA_FINE_DUST}</option>
+        </Select>
+        {sidoAirQualities?.map((sido, sidoIndex) => (
+          <SidoRank
+            key={sido.sidoName}
+            rank={sidoIndex + 1}
+            sidoName={sido.sidoName}
+            fineDustScale={sido.fineDustScale}
+            ultraFineDustScale={sido.ultraFineDustScale}
+            fineDustGrade={sido.fineDustGrade}
+            ultraFineDustGrade={sido.ultraFineDustGrade}
+          />
+        ))}
+      </Flex>
+    </Box>
   );
 };
 
 export default Ranking;
-
-const Mid = styled.div`
-  height: 100vh;
-`;
-
-const State = styled.div`
-  margin-top: 8vh;
-  font-size: 4vw;
-  margin-bottom: 0.5rem;
-  text-align: center;
-  font-weight: 400;
-  color: white;
-  @media only screen and (min-width: 768px) {
-    font-size: 30px;
-  }
-`;
-
-const Time = styled.div`
-  font-size: 3.3vw;
-  margin: 0 0 1.5rem 0;
-  text-align: center;
-  font-weight: 100;
-  color: white;
-  @media only screen and (min-width: 768px) {
-    font-size: 24px;
-  }
-`;
-
-const Middle = styled.div`
-  width: 80%;
-  margin: 0 auto;
-  text-align: center;
-  border-radius: 10px 10px 0 0;
-  font-weight: 300;
-  background-color: white;
-`;
-
-const Location = styled.div`
-  font-size: 6vw;
-  padding-top: 1.5rem;
-  text-align: center;
-  font-weight: 600;
-  @media only screen and (min-width: 768px) {
-    font-size: 30px;
-  }
-`;
-
-const Text = styled.div`
-  font-size: 3.5vw;
-  text-align: center;
-  padding: 2vh 0 0.8vh 0;
-  font-weight: 400;
-  color: #9dadb6;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-  }
-`;
-
-const Rating = styled.div`
-  display: flex;
-  justify-content: center;
-  background-color: #f6f6f6;
-  font-size: 3vh;
-  text-align: center;
-  font-weight: 700;
-  @media only screen and (min-width: 768px) {
-    border-radius: 20px 20px 0 0;
-  }
-`;
-
-const RatingWidth = styled.div`
-  width: 70%;
-`;
-
-const DustRating = styled.div`
-  display: flex;
-  margin: 0 auto;
-  width: 70%;
-  justify-content: center;
-  margin-top: 4vh;
-  margin-bottom: 2vh;
-  padding: 1vh 3vw;
-  background-color: #44b7f7;
-  border-radius: 20px;
-  font-size: 3.5vw;
-  color: white;
-  text-align: center;
-  font-weight: 400;
-  @media only screen and (min-width: 768px) {
-    font-size: 20px;
-    padding: 10px 40px;
-  }
-`;

--- a/src/styles/globalStyle.css
+++ b/src/styles/globalStyle.css
@@ -16,18 +16,6 @@
   font-weight: 600;
 }
 
-#root > div {
-  @media all and (min-width: 1024px) {
-    width: 600px;
-  }
-  @media all and (min-width: 768px) and (max-width: 1023px) {
-    width: 600px;
-  }
-  @media all and (max-width: 767px) {
-    width: 100%;
-  }
-}
-
 .circle-marker {
   width: 1.2rem;
   height: 1.2rem;

--- a/src/styles/globalStyle.css
+++ b/src/styles/globalStyle.css
@@ -8,7 +8,6 @@
 }
 
 #root {
-  /* height: 100vh; */
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/styles/globalStyle.css
+++ b/src/styles/globalStyle.css
@@ -8,7 +8,7 @@
 }
 
 #root {
-  height: 100vh;
+  /* height: 100vh; */
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #54 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- [x] Ranking 페이지에 chakra-ui 적용하기

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://user-images.githubusercontent.com/76807107/233698986-041b4928-a433-4548-a982-6b95a9b69c0c.png)


![image](https://user-images.githubusercontent.com/76807107/233707736-95be4a6c-baa9-4117-898c-21e1c14e4280.png)


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 기존에 globalStyle.css에서 width에 관한 미디어쿼리가 적용되지 않고 있어 Logo.tsx에서 width를 600px인 37.5rem으로 고정 후 미디어쿼리까지 적용했어요.
- 그리고 globalStyle.css에 #root에 적용된 height: 100vh를 제거했어요. 

## 질문 <!-- 궁금한 부분을 적어주세요 -->
