### PR TITLE
Refactor: dustmap page 수정,개선

### DIFF
--- a/src/components/Dust/DustState.tsx
+++ b/src/components/Dust/DustState.tsx
@@ -50,7 +50,11 @@ const DustState = ({ fineDust, ultraFineDust, kindOfDust }: DustStateProps) => {
   return (
     <DustStateColor color={DUST_RATE_COLOR[discriminateDust()]}>
       <Box fontSize={`1.5vh`}>{`${
-        kindOfDust === 'avg' ? `` : `${fineDust}㎍/㎥`
+        kindOfDust === 'avg'
+          ? ``
+          : `${
+              kindOfDust === DUST_KIND.FINE_DUST ? fineDust : ultraFineDust
+            }㎍/㎥`
       }`}</Box>
       <Box display={'flex'} flexDirection={'column'} justifyContent={'center'}>
         {DUST_ICON[discriminateDust()]}

--- a/src/components/Dust/DustState.tsx
+++ b/src/components/Dust/DustState.tsx
@@ -49,13 +49,13 @@ const DustState = ({ fineDust, ultraFineDust, kindOfDust }: DustStateProps) => {
 
   return (
     <DustStateColor color={DUST_RATE_COLOR[discriminateDust()]}>
-      <Box fontSize={`1.5vh`}>{`${
-        kindOfDust === 'avg'
-          ? ``
-          : `${
-              kindOfDust === DUST_KIND.FINE_DUST ? fineDust : ultraFineDust
-            }㎍/㎥`
-      }`}</Box>
+      {kindOfDust === 'avg' ? (
+        ''
+      ) : (
+        <Box fontSize={`1.5vh`}>{`${`${
+          kindOfDust === DUST_KIND.FINE_DUST ? fineDust : ultraFineDust
+        }㎍/㎥`}`}</Box>
+      )}
       <Box display={'flex'} flexDirection={'column'} justifyContent={'center'}>
         {DUST_ICON[discriminateDust()]}
         {DUST_RATE[discriminateDust()]}

--- a/src/components/Dust/DustState.tsx
+++ b/src/components/Dust/DustState.tsx
@@ -32,7 +32,7 @@ const DUST_KIND = {
 };
 
 const DustState = ({ fineDust, ultraFineDust, kindOfDust }: DustStateProps) => {
-  const dustDensityNumber = +fineDust;
+  const dustDensityNumber = (fineDust + ultraFineDust) / 2;
   if (isNaN(dustDensityNumber))
     return <DustStateColor style={{ color: '#666666' }}>측정중</DustStateColor>;
 
@@ -40,9 +40,9 @@ const DustState = ({ fineDust, ultraFineDust, kindOfDust }: DustStateProps) => {
     if (kindOfDust === DUST_KIND.AVG) {
       return AVERAGE_DUST_DENSITY.findIndex((v) => dustDensityNumber < +v);
     } else if (kindOfDust === DUST_KIND.FINE_DUST) {
-      return FINE_DUST_DENSITY.findIndex((v) => dustDensityNumber < +v);
+      return FINE_DUST_DENSITY.findIndex((v) => fineDust < +v);
     } else if (kindOfDust === DUST_KIND.ULTRA_FINE_DUST) {
-      return ULTRA_FINE_DUST_DENSITY.findIndex((v) => dustDensityNumber < +v);
+      return ULTRA_FINE_DUST_DENSITY.findIndex((v) => ultraFineDust < +v);
     }
     return 0;
   };

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -68,16 +68,18 @@ const Map = () => {
 
   useEffect(() => {
     document.querySelectorAll('.dust-info-marker').forEach((city) => {
-      city.addEventListener('click', onOpen);
-      if (city instanceof HTMLElement) {
+      city.addEventListener('click', () => {
         setCity(city.id);
-        city.dataset.finedustscale
-          ? setFineDustScale(+city.dataset.finedustscale)
-          : '';
-        city.dataset.ultrafinedustscale
-          ? setUltraFineDustScale(+city.dataset.ultrafinedustscale)
-          : '';
-      }
+        if (city instanceof HTMLElement) {
+          city.dataset.finedustscale
+            ? setFineDustScale(+city.dataset.finedustscale)
+            : '';
+          city.dataset.ultrafinedustscale
+            ? setUltraFineDustScale(+city.dataset.ultrafinedustscale)
+            : '';
+        }
+        onOpen();
+      });
     });
 
     return () => {

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -87,7 +87,7 @@ const Map = () => {
         city.removeEventListener('click', onOpen);
       });
     };
-  }, [currentLocation]);
+  }, [currentLocation, zoomLevel]);
 
   useEffect(() => {
     if (!map || !airQualityBySido || !allLocation) return;

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -37,8 +37,8 @@ const Map = () => {
   const sidoDustInfoMarkers: kakao.maps.CustomOverlay[] = [];
   const cityDustInfoMarkers: kakao.maps.CustomOverlay[] = [];
   const [city, setCity] = useState('동네 정보를 받아오지 못했어요');
-  const [fineDustScale, setFineDustScale] = useState('측정중');
-  const [ultraFineDustScale, setUltraFineDustScale] = useState('측정중');
+  const [fineDustScale, setFineDustScale] = useState(0);
+  const [ultraFineDustScale, setUltraFineDustScale] = useState(0);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const {
     map,
@@ -72,10 +72,10 @@ const Map = () => {
       if (city instanceof HTMLElement) {
         setCity(city.id);
         city.dataset.finedustscale
-          ? setFineDustScale(city.dataset.finedustscale)
+          ? setFineDustScale(+city.dataset.finedustscale)
           : '';
         city.dataset.ultrafinedustscale
-          ? setUltraFineDustScale(city.dataset.ultrafinedustscale)
+          ? setUltraFineDustScale(+city.dataset.ultrafinedustscale)
           : '';
       }
     });
@@ -198,11 +198,15 @@ const Map = () => {
           <ModalCloseButton borderColor={'#ffffff'} />
           <ModalBody>
             {FINE_DUST}
-            <DustState fineDust={0} ultraFineDust={0} kindOfDust={'fineDust'} />
+            <DustState
+              fineDust={fineDustScale}
+              ultraFineDust={ultraFineDustScale}
+              kindOfDust={'fineDust'}
+            />
             {ULTRA_FINE_DUST}
             <DustState
-              fineDust={0}
-              ultraFineDust={0}
+              fineDust={fineDustScale}
+              ultraFineDust={ultraFineDustScale}
               kindOfDust={'ultraFineDust'}
             />
           </ModalBody>

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -67,29 +67,6 @@ const Map = () => {
   const { data: allLocation } = useQuery(['all-location'], getAllLocation);
 
   useEffect(() => {
-    document.querySelectorAll('.dust-info-marker').forEach((city) => {
-      city.addEventListener('click', () => {
-        setCity(city.id);
-        if (city instanceof HTMLElement) {
-          city.dataset.finedustscale
-            ? setFineDustScale(+city.dataset.finedustscale)
-            : '';
-          city.dataset.ultrafinedustscale
-            ? setUltraFineDustScale(+city.dataset.ultrafinedustscale)
-            : '';
-        }
-        onOpen();
-      });
-    });
-
-    return () => {
-      document.querySelectorAll('.dust-info-marker').forEach((city) => {
-        city.removeEventListener('click', onOpen);
-      });
-    };
-  }, [currentLocation, zoomLevel]);
-
-  useEffect(() => {
     if (!map || !airQualityBySido || !allLocation) return;
 
     airQualityBySido.forEach(
@@ -170,6 +147,29 @@ const Map = () => {
       }
     };
   }, [airQualityByCity]);
+
+  useEffect(() => {
+    document.querySelectorAll('.dust-info-marker').forEach((city) => {
+      city.addEventListener('click', () => {
+        setCity(city.id);
+        if (city instanceof HTMLElement) {
+          city.dataset.finedustscale
+            ? setFineDustScale(+city.dataset.finedustscale)
+            : '';
+          city.dataset.ultrafinedustscale
+            ? setUltraFineDustScale(+city.dataset.ultrafinedustscale)
+            : '';
+        }
+        onOpen();
+      });
+    });
+
+    return () => {
+      document.querySelectorAll('.dust-info-marker').forEach((city) => {
+        city.removeEventListener('click', onOpen);
+      });
+    };
+  }, [currentLocation, zoomLevel]);
 
   return (
     <Box position="relative" width="100%" height="100%">

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, RefObject } from 'react';
 import { INIT_LOCATION, CENTER_LOCATION, SIDO_GROUP } from '@/utils/constants';
-import { RefObject } from 'react';
 
 const INIT_ZOOM_LEVEL = 5;
 const MAX_ZOOM_LEVEL = 8;
@@ -10,7 +9,7 @@ interface useMapProps {
 }
 
 const useMap = ({ mapRef }: useMapProps) => {
-  const [myDeviceLocation, setMyDeviceLocation] = useState(INIT_LOCATION); // 내 디바이스 위치
+  const [myDeviceLocation, setMyDeviceLocation] = useState(INIT_LOCATION);
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
   const [zoomLevel, setZoomLevel] = useState(INIT_ZOOM_LEVEL);
   const [currentCity, setCurrentCity] = useState(SIDO_GROUP[0].sidoName); // 서울

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { INIT_LOCATION, CENTER_LOCATION } from '@/utils/constants';
+import { INIT_LOCATION, CENTER_LOCATION, SIDO_GROUP } from '@/utils/constants';
 import { RefObject } from 'react';
 
 const INIT_ZOOM_LEVEL = 5;
@@ -13,7 +13,7 @@ const useMap = ({ mapRef }: useMapProps) => {
   const [location, setLocation] = useState(INIT_LOCATION); // 내 디바이스 위치
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
   const [zoomLevel, setZoomLevel] = useState(INIT_ZOOM_LEVEL);
-  const [currentCity, setCurrentCity] = useState('서울');
+  const [currentCity, setCurrentCity] = useState(SIDO_GROUP[0].sidoName); // 서울
   const [currentLocation, setCurrentLocation] = useState(INIT_LOCATION); // 지도를 움직이면 변화하는 위치
 
   useEffect(() => {

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -10,7 +10,7 @@ interface useMapProps {
 }
 
 const useMap = ({ mapRef }: useMapProps) => {
-  const [location, setLocation] = useState(INIT_LOCATION); // 내 디바이스 위치
+  const [myDeviceLocation, setMyDeviceLocation] = useState(INIT_LOCATION); // 내 디바이스 위치
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
   const [zoomLevel, setZoomLevel] = useState(INIT_ZOOM_LEVEL);
   const [currentCity, setCurrentCity] = useState(SIDO_GROUP[0].sidoName); // 서울
@@ -20,6 +20,22 @@ const useMap = ({ mapRef }: useMapProps) => {
     kakao.maps.load(() => {
       const success = (pos: GeolocationPosition) => {
         if (!mapRef.current) return;
+
+        setMyDeviceLocation({
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+        });
+
+        const geocoder = new kakao.maps.services.Geocoder();
+        geocoder.coord2Address(
+          pos.coords.longitude,
+          pos.coords.latitude,
+          (result, status) => {
+            if (status === kakao.maps.services.Status.OK) {
+              setCurrentCity(result[0].address.address_name.split(' ')[0]);
+            }
+          }
+        );
 
         const options = {
           center: new kakao.maps.LatLng(
@@ -104,7 +120,12 @@ const useMap = ({ mapRef }: useMapProps) => {
     if (!map) return;
 
     map.setLevel(INIT_ZOOM_LEVEL, { animate: true });
-    map.setCenter(new kakao.maps.LatLng(location.latitude, location.longitude));
+    map.setCenter(
+      new kakao.maps.LatLng(
+        myDeviceLocation.latitude,
+        myDeviceLocation.longitude
+      )
+    );
   };
 
   const handleZoomIn = () => {


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #57 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 이제 지도 화면 첫 접속 시 사용자 디바이스 근처에 미세먼지 관측소가 있다면 마커가 바로 표기됩니다.
- 마커 클릭 시 상세정보 모달과 마커의 정보가 일치하지 않던 문제를 수정했습니다.
- 상세 정보 모달에서 미세먼지와 초미세먼지 수치가 정상적으로 표기되지 않던 문제를 수정했습니다.
- 지도를 축소 할 때 다른 sido가 지도에 표기 되면 해당 지역의 마커는 click 이벤트가 동작하지 않던 문제를 수정했습니다.

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![chrome-capture-2023-3-22](https://user-images.githubusercontent.com/12118892/233773803-460545d6-7fdd-462d-85bd-e0c53e9d6468.gif)


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- DustState.tsx의 props들이 적절히 사용되고 있는 것 같지 않아서 수정했습니다.
## 질문 <!-- 궁금한 부분을 적어주세요 -->
- 지도에 마커가 바로 표기되기는 하나, 지도를 한 번 움직이거나 줌 인/아웃을 해야 클릭 이벤트가 정상동작합니다. 이벤트 리스너를 부착하는 useEffect의 deps를 [currentLocation, zoomLevel] 로 해놓은 상태인데 지도 화면 첫 입장시에도 click 이벤트가 발생하게 하려면 어떻게 해야할까요..? 컴포넌트가 마운트 될 때 event 리스너도 적용될 줄 알았는데 안되더라구요!
