### PR TITLE
refactor: DustForcast 페이지 스타일 개선

### DIFF
--- a/src/apis/dustForecast.ts
+++ b/src/apis/dustForecast.ts
@@ -16,13 +16,14 @@ const getTodayDate = () => {
 
 interface DustForcast {
   imageUrl1: string;
+  informCause: string;
   informOverall: string;
 }
 
 export const getDustForcast = async () => {
   try {
     const response = await axios.get(
-      `${VITE_MINU_DUST_FRCST_DSPTH_URL}?searchDate=${getTodayDate()}&returnType=json&serviceKey=${VITE_AIR_QUALITY_API_KEY}&numOfRows=100&pageNo=1`
+      `${VITE_MINU_DUST_FRCST_DSPTH_URL}?searchDate=${getTodayDate()}&returnType=json&serviceKey=${VITE_AIR_QUALITY_API_KEY}&numOfRows=10&pageNo=1`
     );
 
     if (response.status !== 200) {
@@ -30,7 +31,8 @@ export const getDustForcast = async () => {
     }
 
     return response.data.response.body.items.find(
-      (forcast: DustForcast) => forcast.imageUrl1 && forcast.informOverall
+      (forcast: DustForcast) =>
+        forcast.imageUrl1 && forcast.informCause && forcast.informOverall
     );
   } catch (error) {
     console.error(error);

--- a/src/components/Dust/DustState.tsx
+++ b/src/components/Dust/DustState.tsx
@@ -1,78 +1,61 @@
-import { Box, Flex } from '@chakra-ui/react';
-import styled from '@emotion/styled';
+import { Box, Flex, Text } from '@chakra-ui/react';
 import {
   BsEmojiHeartEyes,
   BsEmojiNeutral,
   BsEmojiFrown,
   BsEmojiAngry,
 } from 'react-icons/bs';
+import { DUST_SCALE_COLOR } from '@/utils/map';
 
 interface DustStateProps {
-  fineDust: number;
-  ultraFineDust: number;
-  kindOfDust: string;
+  dustGrade: number;
 }
 
-const DUST_RATE_COLOR = ['#1E64EE', '#00D500', '#F95A20', '#E73532'];
-const DUST_RATE = ['좋음', '보통', '나쁨', '매우 나쁨'];
-const AVERAGE_DUST_DENSITY = [2, 3, 4, 10];
-const FINE_DUST_DENSITY = [80, 150, 300, 1200];
-const ULTRA_FINE_DUST_DENSITY = [15, 35, 75, 1200];
-const DUST_ICON = [
-  <BsEmojiHeartEyes />,
-  <BsEmojiNeutral />,
-  <BsEmojiFrown />,
-  <BsEmojiAngry />,
-];
+type GradeType = 'GOOD' | 'NORMAL' | 'BAD' | 'DANGER';
 
-const DUST_KIND = {
-  AVG: 'avg',
-  FINE_DUST: 'fineDust',
-  ULTRA_FINE_DUST: 'ultraFineDust',
+interface Grade {
+  [key: number]: GradeType;
+}
+
+const DUST_GRADE: Grade = {
+  1: 'GOOD',
+  2: 'NORMAL',
+  3: 'BAD',
+  4: 'DANGER',
 };
 
-const DustState = ({ fineDust, ultraFineDust, kindOfDust }: DustStateProps) => {
-  const dustDensityNumber = (fineDust + ultraFineDust) / 2;
-  if (isNaN(dustDensityNumber))
-    return <DustStateColor style={{ color: '#666666' }}>측정중</DustStateColor>;
+const DUST_STATE = {
+  GOOD: '좋음',
+  NORMAL: '보통',
+  BAD: '나쁨',
+  DANGER: '매우 나쁨',
+};
 
-  const discriminateDust = () => {
-    if (kindOfDust === DUST_KIND.AVG) {
-      return AVERAGE_DUST_DENSITY.findIndex((v) => dustDensityNumber < +v);
-    } else if (kindOfDust === DUST_KIND.FINE_DUST) {
-      return FINE_DUST_DENSITY.findIndex((v) => fineDust < +v);
-    } else if (kindOfDust === DUST_KIND.ULTRA_FINE_DUST) {
-      return ULTRA_FINE_DUST_DENSITY.findIndex((v) => ultraFineDust < +v);
-    }
-    return 0;
-  };
+const DUST_STATE_ICON = {
+  GOOD: <BsEmojiHeartEyes />,
+  NORMAL: <BsEmojiNeutral />,
+  BAD: <BsEmojiFrown />,
+  DANGER: <BsEmojiAngry />,
+};
+
+const DustState = ({ dustGrade }: DustStateProps) => {
+  const state = DUST_GRADE[dustGrade];
 
   return (
-    <DustStateColor color={DUST_RATE_COLOR[discriminateDust()]}>
-      {kindOfDust === 'avg' ? (
-        ''
-      ) : (
-        <Box fontSize={3}>{`${
-          kindOfDust === DUST_KIND.FINE_DUST ? fineDust : ultraFineDust
-        }㎍/㎥`}</Box>
-      )}
-      <Flex flexDirection="column" justifyContent="center">
-        {DUST_ICON[discriminateDust()]}
-        {DUST_RATE[discriminateDust()]}
-      </Flex>
-    </DustStateColor>
+    <Flex flexDirection="column" justifyContent="center" alignItems="center">
+      <Box color={DUST_SCALE_COLOR[state]} mb={1}>
+        {DUST_STATE_ICON[state]}
+      </Box>
+      <Text
+        as="p"
+        fontSize={20}
+        fontWeight={700}
+        color={DUST_SCALE_COLOR[state]}
+      >
+        {DUST_STATE[state]}
+      </Text>
+    </Flex>
   );
 };
 
 export default DustState;
-
-const DustStateColor = styled.div`
-  display: flex;
-  justify-content: center;
-  width: 36%;
-  margin-right: 1rem;
-  font-size: 1.4rem;
-  text-align: center;
-  font-weight: 700;
-  color: ${(props) => props.color};
-`;

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -200,17 +200,9 @@ const Map = () => {
           <ModalCloseButton borderColor={'#ffffff'} />
           <ModalBody>
             {FINE_DUST}
-            <DustState
-              fineDust={fineDustScale}
-              ultraFineDust={ultraFineDustScale}
-              kindOfDust={'fineDust'}
-            />
+            <DustState dustGrade={fineDustScale} />
             {ULTRA_FINE_DUST}
-            <DustState
-              fineDust={fineDustScale}
-              ultraFineDust={ultraFineDustScale}
-              kindOfDust={'ultraFineDust'}
-            />
+            <DustState dustGrade={ultraFineDustScale} />
           </ModalBody>
           <ModalFooter>
             <Button

--- a/src/components/Ranking/RankItem.tsx
+++ b/src/components/Ranking/RankItem.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { Flex, Text, Box } from '@chakra-ui/react';
 import DustState from '@/components/Dust/DustState';
 import { FINE_DUST, ROUTE, ULTRA_FINE_DUST } from '@/utils/constants';
+import { getDustAverageGrade } from '@/utils/dustGrade';
 import type { CityAirQuality } from '@/type';
 
 interface RankItemProps extends CityAirQuality {
@@ -18,6 +19,10 @@ const RankItem = ({
   dataTime,
 }: RankItemProps) => {
   const navigate = useNavigate();
+  const dustAverageGrade = getDustAverageGrade(
+    fineDustGrade,
+    ultraFineDustGrade
+  );
 
   const handlePageNavigate = () => {
     navigate(ROUTE.DUST_FORECAST, {
@@ -55,9 +60,7 @@ const RankItem = ({
         {cityName}
       </Text>
       <Box width="26%" mr={8}>
-        <DustState
-          dustGrade={Math.floor((fineDustGrade + ultraFineDustGrade) / 2)}
-        />
+        <DustState dustGrade={dustAverageGrade} />
       </Box>
       <Flex direction="column" justifyContent="center" flexGrow={1}>
         <Flex justifyContent="space-between" py={1}>

--- a/src/components/Ranking/RankItem.tsx
+++ b/src/components/Ranking/RankItem.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { Flex, Text } from '@chakra-ui/react';
+import { Flex, Text, Box } from '@chakra-ui/react';
 import DustState from '@/components/Dust/DustState';
 import { FINE_DUST, ROUTE, ULTRA_FINE_DUST } from '@/utils/constants';
 import type { CityAirQuality } from '@/type';
@@ -54,11 +54,11 @@ const RankItem = ({
       >
         {cityName}
       </Text>
-      <DustState
-        fineDust={fineDustGrade}
-        ultraFineDust={ultraFineDustGrade}
-        kindOfDust="avg"
-      />
+      <Box width="26%" mr={8}>
+        <DustState
+          dustGrade={Math.floor((fineDustGrade + ultraFineDustGrade) / 2)}
+        />
+      </Box>
       <Flex direction="column" justifyContent="center" flexGrow={1}>
         <Flex justifyContent="space-between" py={1}>
           <Text

--- a/src/components/Ranking/SidoRank.tsx
+++ b/src/components/Ranking/SidoRank.tsx
@@ -3,6 +3,7 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import { DustState } from '@/components/Dust';
 import CityRank from './CityRank';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
+import { getDustAverageGrade } from '@/utils/dustGrade';
 
 interface SidoRankProps {
   rank: number;
@@ -22,6 +23,10 @@ const SidoRank = ({
   ultraFineDustGrade,
 }: SidoRankProps) => {
   const [isShow, setIsShow] = useState(false);
+  const dustAverageGrade = getDustAverageGrade(
+    fineDustGrade,
+    ultraFineDustGrade
+  );
 
   const handleSidoClick = () => {
     setIsShow((isShow) => !isShow);
@@ -54,9 +59,7 @@ const SidoRank = ({
           {sidoName}
         </Text>
         <Box width="26%" mr={8}>
-          <DustState
-            dustGrade={Math.floor((fineDustGrade + ultraFineDustGrade) / 2)}
-          />
+          <DustState dustGrade={dustAverageGrade} />
         </Box>
         <Flex direction="column" justifyContent="center" flexGrow={1}>
           <Flex justifyContent="space-between" py={1}>

--- a/src/components/Ranking/SidoRank.tsx
+++ b/src/components/Ranking/SidoRank.tsx
@@ -53,11 +53,11 @@ const SidoRank = ({
         >
           {sidoName}
         </Text>
-        <DustState
-          fineDust={fineDustGrade}
-          ultraFineDust={ultraFineDustGrade}
-          kindOfDust="avg"
-        />
+        <Box width="26%" mr={8}>
+          <DustState
+            dustGrade={Math.floor((fineDustGrade + ultraFineDustGrade) / 2)}
+          />
+        </Box>
         <Flex direction="column" justifyContent="center" flexGrow={1}>
           <Flex justifyContent="space-between" py={1}>
             <Text as="p" fontSize={16} fontWeight={500}>

--- a/src/pages/DustForecast.tsx
+++ b/src/pages/DustForecast.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Center, Box } from '@chakra-ui/react';
+import { Center, Box, Text, Flex, Image } from '@chakra-ui/react';
 import { DustState } from '@/components/Dust';
 import { getDustForcast } from '@/apis/dustForecast';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
@@ -35,61 +35,75 @@ const DustForecast = () => {
   }
 
   return (
-    <Box
-      height="100vh"
-      display="flex"
-      flexDirection="column"
-      alignItems="center"
-    >
-      <Box
-        alignItems="center"
-        marginTop="8vh"
-        borderRadius="20px"
-        textAlign="center"
-        fontWeight="400"
-        color="white"
-        backgroundColor="#53caf2"
+    <Box textAlign="center">
+      <Text
+        as="h1"
+        fontSize={30}
+        fontWeight={600}
+        color="#ffffff"
+        mt={20}
+        mb={4}
       >
-        {cityName}의 {FINE_DUST} 농도는 다음과 같습니다.
-      </Box>
-      <Box
-        margin="0 0 1.5rem 0"
-        textAlign="center"
-        fontWeight="100"
-        color="white"
-      >
+        {cityName}의 미세먼지 농도는 다음과 같습니다.
+      </Text>
+      <Text as="p" fontSize={20} fontWeight={300} color="#ffffff" mb={6}>
         {dataTime} 기준
-      </Box>
-      <Box width="50%" alignItems="center" backgroundColor="white">
-        <Box
-          marginTop="3rem"
-          marginBottom="3rem"
-          display="flex"
-          flexDirection="row"
-        >
-          <Box padding="0 10% 0 10%" width="100%">
-            <div>{FINE_DUST}</div>
-            <div>{fineDustScale}</div>
-            <DustState
-              fineDust={fineDustGrade}
-              ultraFineDust={ultraFineDustGrade}
-              kindOfDust="fineDust"
-            />
+      </Text>
+      <Box borderRadius={10} mb={20} py={10} px={8} bg="#ffffff">
+        <Flex alignItems="center" pb={10} borderBottom="1px solid #dfdfdf">
+          <Box flexGrow={1} borderRight="1px solid #dfdfdf">
+            <Text as="p" fontSize={22} fontWeight={600} mb={2}>
+              {FINE_DUST}
+            </Text>
+            <Flex justifyContent="center" alignItems="center">
+              <Text as="p" fontSize={48} fontWeight={800} mr={5}>
+                {fineDustScale}
+              </Text>
+              <Box my={3}>
+                <DustState dustGrade={fineDustGrade} />
+              </Box>
+            </Flex>
           </Box>
-          <Box padding="0 10% 0 10%" width="100%">
-            <div>{ULTRA_FINE_DUST}</div>
-            <div>{ultraFineDustScale}</div>
-            <DustState
-              fineDust={fineDustGrade}
-              ultraFineDust={ultraFineDustGrade}
-              kindOfDust="ultraFineDust"
-            />
+          <Box flexGrow={1}>
+            <Text as="p" fontSize={22} fontWeight={600} mb={2}>
+              {ULTRA_FINE_DUST}
+            </Text>
+            <Flex justifyContent="center" alignItems="center">
+              <Text as="p" fontSize={48} fontWeight={800} mr={5}>
+                {ultraFineDustScale}
+              </Text>
+              <Box my={3}>
+                <DustState dustGrade={ultraFineDustGrade} />
+              </Box>
+            </Flex>
           </Box>
-        </Box>
-        <Box padding="10%" display="flex" flexWrap="wrap" alignItems="center">
-          <div>{dustForecast.informOverall}</div>
-          <img src={dustForecast.imageUrl1} alt="기상 이미지를 준비중입니다." />
-        </Box>
+        </Flex>
+        <Flex direction="column" mt={10}>
+          <Text as="p" fontSize={22} fontWeight={600} textAlign="center" mb={6}>
+            기상 예보
+          </Text>
+          <Text
+            fontSize={16}
+            fontWeight={400}
+            textAlign="left"
+            lineHeight={1.4}
+          >
+            {dustForecast.informOverall}
+          </Text>
+          <Text
+            fontSize={16}
+            fontWeight={400}
+            textAlign="left"
+            lineHeight={1.4}
+          >
+            {dustForecast.informCause}
+          </Text>
+          <Image
+            src={dustForecast.imageUrl1}
+            alt="기상 이미지를 준비중입니다."
+            mt={8}
+          />
+        </Flex>
       </Box>
     </Box>
   );

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -6,6 +6,7 @@ import { DustState } from '@/components/Dust';
 import ProgressBar from '@/components/ProgressBar';
 import SidoRank from '@/components/Ranking/SidoRank';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
+import { getDustAverageGrade } from '@/utils/dustGrade';
 import { getSidoAirQualities, getSidoAirQuality } from '@/apis/airQuality';
 
 type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
@@ -60,6 +61,11 @@ const Ranking = () => {
     );
   }
 
+  const dustAverageGrade = getDustAverageGrade(
+    sidoAirQuality.fineDustGrade,
+    sidoAirQuality.ultraFineDustGrade
+  );
+
   return (
     <Box textAlign="center">
       <Text
@@ -90,13 +96,7 @@ const Ranking = () => {
           현재의 대기질 지수는
         </Text>
         <Center my={5}>
-          <DustState
-            dustGrade={Math.floor(
-              (sidoAirQuality.fineDustGrade +
-                sidoAirQuality.ultraFineDustGrade) /
-                2
-            )}
-          />
+          <DustState dustGrade={dustAverageGrade} />
         </Center>
         <ProgressBar id="fineDust" state={sidoAirQuality.fineDustScale}>
           {FINE_DUST}

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -91,9 +91,11 @@ const Ranking = () => {
         </Text>
         <Center my={5}>
           <DustState
-            fineDust={sidoAirQuality.fineDustGrade}
-            ultraFineDust={sidoAirQuality.ultraFineDustGrade}
-            kindOfDust="avg"
+            dustGrade={Math.floor(
+              (sidoAirQuality.fineDustGrade +
+                sidoAirQuality.ultraFineDustGrade) /
+                2
+            )}
           />
         </Center>
         <ProgressBar id="fineDust" state={sidoAirQuality.fineDustScale}>

--- a/src/utils/dustGrade.ts
+++ b/src/utils/dustGrade.ts
@@ -1,0 +1,6 @@
+export const getDustAverageGrade = (
+  fineDustGrade: number,
+  ultraFineDustGrade: number
+) => {
+  return Math.floor((fineDustGrade + ultraFineDustGrade) / 2);
+};


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #61 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- [x] DustForcast 페이지 스타일 개선
- [x] DustState 컴포넌트 리팩토링

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://user-images.githubusercontent.com/76807107/233827919-5141f8a0-e4e1-4c01-8130-b9b4590a2cc8.png)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 기상 예보 데이터 글자 수가 너무 적은 것 같아 informOverall 데이터 뿐만 아니라 informCause 데이터도 추가했어요.
- 기존에는 DustState 컴포넌트의 prop으로 fineDust, ultraFineDust, kindOfDust를 받고 있었어요. 근데 avg가 아닌 경우에도 fineDust, ultraFineDust 데이터를 모두 받는 것이 좋지 못하다고 생각해서 dustGrade라는 하나의 prop을 갖도록 수정했어요. 근데 prop을 넘겨줄 때 값을 계산해서 넘겨주는 게 맞는지는 잘 모르겠어요.
```typescript
// 평균 상태를 나타낼 때
<DustState dustGrade={Math.floor((fineDustGrade + ultraFineDustGrade) / 2)} />

// 평균 상태를 나타내지 않을 때
<DustState dustGrade={fineDustScale} />
<DustState dustGrade={ultraFineDustScale} />
```
## 질문 <!-- 궁금한 부분을 적어주세요 -->
DustState 컴포넌트에 타입스크립트를 봐주세요.