### PR TITLE
fix: 배포링크 새로 고침시 페이지 누락 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #82 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 배포 링크에서 새로 고침 시  vercel 기본 404 페이지가 뜨던 현상을 수정합니다.
## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
[chrome-capture-2023-4-4.webm](https://user-images.githubusercontent.com/12118892/236182092-98e584b2-bf2e-423a-84db-c99b4af3d2a6.webm)
새로 고침 해도 페이지에서 이탈하지 않습니다.
## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 테스트를 위해서 fork 받은 브랜치를 임시로 배포하여 테스트 했습니다.
## 질문 <!-- 궁금한 부분을 적어주세요 -->
App.tsx에서 예외 경로를 처리하는 방법이 다음과 같습니다.
```<Route path="*" element={<Navigate replace to={ROUTE.HOME} />} />```
path를 '/*' 으로 수정해야 할까요?