### PR TITLE
feat: 특정 지역의 미세먼지 농도에 따른 Ranking 페이지 배경색 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta property="og:description" content="미세먼지 농도가 궁금한 지역은?" />
     <meta name="description" content="Web site created using vite" />
     <link
-      rel="stylesheet"
+      rel="preload stylesheet"
       as="style"
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/variable/pretendardvariable-dynamic-subset.css"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { ChakraProvider } from '@chakra-ui/react';
 import {
   createBrowserRouter,
   createRoutesFromElements,
@@ -5,7 +6,6 @@ import {
   RouterProvider,
   Navigate,
 } from 'react-router-dom';
-
 import Logo from '@/components/Logo';
 import {
   ChoicePage,
@@ -14,6 +14,7 @@ import {
   DustMapPage,
 } from '@/pages';
 import { ROUTE } from '@/utils/constants';
+import theme from './styles/theme';
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -28,7 +29,11 @@ const router = createBrowserRouter(
 );
 
 const App = () => {
-  return <RouterProvider router={router} />;
+  return (
+    <ChakraProvider theme={theme}>
+      <RouterProvider router={router} />
+    </ChakraProvider>
+  );
 };
 
 export default App;

--- a/src/components/DustForcast/DustChart.tsx
+++ b/src/components/DustForcast/DustChart.tsx
@@ -11,13 +11,9 @@ import {
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 import { getDustHistory } from '@/apis/dustHistory';
+import theme from '@/styles/theme';
 import type { DustHistory } from '@/types/dust';
-import {
-  FINE_DUST,
-  ULTRA_FINE_DUST,
-  DUST_GRADE,
-  DUST_SCALE_COLOR,
-} from '@/utils/constants';
+import { FINE_DUST, ULTRA_FINE_DUST, DUST_GRADE } from '@/utils/constants';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip);
 
@@ -50,14 +46,14 @@ const DustChart = ({ cityName }: DustChartProps) => {
         label: FINE_DUST,
         data: dustHistories.map((history) => history.fineDustScale),
         backgroundColor: dustHistories.map(
-          (history) => DUST_SCALE_COLOR[DUST_GRADE[history.fineDustGrade]]
+          (history) => theme.colors[DUST_GRADE[history.fineDustGrade]]
         ),
       },
       {
         label: ULTRA_FINE_DUST,
         data: dustHistories.map((history) => history.ultraFineDustScale),
         backgroundColor: dustHistories.map(
-          (history) => DUST_SCALE_COLOR[DUST_GRADE[history.ultraFineDustGrade]]
+          (history) => theme.colors[DUST_GRADE[history.ultraFineDustGrade]]
         ),
       },
     ],

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,4 +1,4 @@
-import { Image } from '@chakra-ui/react';
+import { Image, Box } from '@chakra-ui/react';
 import { Outlet } from 'react-router-dom';
 
 const Logo = () => (
@@ -15,9 +15,9 @@ const Logo = () => (
       cursor="pointer"
       onClick={() => window.open('https://tooo1.tistory.com')}
     />
-    <main>
+    <Box>
       <Outlet />
-    </main>
+    </Box>
   </>
 );
 

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,6 +1,5 @@
 import { Image } from '@chakra-ui/react';
 import { Outlet } from 'react-router-dom';
-import { Box } from '@chakra-ui/react';
 
 const Logo = () => (
   <>
@@ -16,9 +15,9 @@ const Logo = () => (
       cursor="pointer"
       onClick={() => window.open('https://tooo1.tistory.com')}
     />
-    <Box width={{ base: '100%', md: '37.5rem' }}>
+    <main>
       <Outlet />
-    </Box>
+    </main>
   </>
 );
 

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -20,12 +20,12 @@ import { getAllLocation } from '@/apis/location';
 import DustLevel from '@/components/common/DustLevel';
 import DustState from '@/components/common/DustState';
 import useMap from '@/hooks/useMap';
+import theme from '@/styles/theme';
 import type { CityDustInfo } from '@/types/dust';
 import {
   FINE_DUST,
   ULTRA_FINE_DUST,
   DUST_GRADE,
-  DUST_SCALE_COLOR,
   CITY_ZOOM_LEVEL,
   MAX_ZOOM_LEVEL,
   COLOR_MARKER_MOUSE_OVER,
@@ -95,7 +95,7 @@ const Map = () => {
           fineDustGrade,
           ultraFineDustGrade
         );
-        const backgroundColor = DUST_SCALE_COLOR[DUST_GRADE[averageGrade]];
+        const backgroundColor = theme.colors[DUST_GRADE[averageGrade]];
         const template = `
           <div class="dust-info-marker" style="background-color: ${backgroundColor};">
             <p class="city-name">${sidoName}</p>
@@ -157,7 +157,7 @@ const Map = () => {
               fineDustGrade,
               ultraFineDustGrade
             );
-            const backgroundColor = DUST_SCALE_COLOR[DUST_GRADE[averageGrade]];
+            const backgroundColor = theme.colors[DUST_GRADE[averageGrade]];
             const template = `
                   <div class="dust-info-marker" id="${cityName}" data-finedustgrade="${fineDustGrade}" data-ultrafinedustgrade="${ultraFineDustGrade}" style="background-color: ${backgroundColor};" >
                     <span>${fineDustScale}/${ultraFineDustScale}</span>                  

--- a/src/components/common/DustLevel.tsx
+++ b/src/components/common/DustLevel.tsx
@@ -1,5 +1,5 @@
 import { Flex, Box } from '@chakra-ui/react';
-import { DUST_SCALE_COLOR } from '@/utils/constants';
+import theme from '@/styles/theme';
 
 interface DustLevelProps {
   direction: 'row' | 'column';
@@ -17,7 +17,7 @@ export const DustLevel = ({ direction = 'row' }: DustLevelProps) => {
       gap={1}
     >
       <Box
-        backgroundColor={DUST_SCALE_COLOR.DANGER}
+        backgroundColor={theme.colors.DANGER}
         borderRadius={20}
         p={3}
         py="0.3rem"
@@ -25,7 +25,7 @@ export const DustLevel = ({ direction = 'row' }: DustLevelProps) => {
         매우
       </Box>
       <Box
-        backgroundColor={DUST_SCALE_COLOR.BAD}
+        backgroundColor={theme.colors.BAD}
         borderRadius={20}
         px={3}
         py="0.3rem"
@@ -33,7 +33,7 @@ export const DustLevel = ({ direction = 'row' }: DustLevelProps) => {
         나쁨
       </Box>
       <Box
-        backgroundColor={DUST_SCALE_COLOR.NORMAL}
+        backgroundColor={theme.colors.NORMAL}
         borderRadius={20}
         px={3}
         py="0.3rem"
@@ -41,7 +41,7 @@ export const DustLevel = ({ direction = 'row' }: DustLevelProps) => {
         보통
       </Box>
       <Box
-        backgroundColor={DUST_SCALE_COLOR.GOOD}
+        backgroundColor={theme.colors.GOOD}
         borderRadius={20}
         px={3}
         py="0.3rem"

--- a/src/components/common/DustState.tsx
+++ b/src/components/common/DustState.tsx
@@ -5,7 +5,8 @@ import {
   BsEmojiFrown,
   BsEmojiAngry,
 } from 'react-icons/bs';
-import { DUST_GRADE, DUST_SCALE_COLOR } from '@/utils/constants';
+import theme from '@/styles/theme';
+import { DUST_GRADE } from '@/utils/constants';
 
 interface DustStateProps {
   dustGrade: number;
@@ -30,14 +31,14 @@ const DustState = ({ dustGrade }: DustStateProps) => {
 
   return (
     <Flex flexDirection="column" justifyContent="center" alignItems="center">
-      <Box color={DUST_SCALE_COLOR[grade]} mb={1}>
+      <Box color={theme.colors[grade]} mb={1}>
         {DUST_GRADE_ICON[grade]}
       </Box>
       <Text
         as="p"
         fontSize={{ base: 16, sm: 20 }}
         fontWeight={700}
-        color={DUST_SCALE_COLOR[grade]}
+        color={theme.colors[grade]}
       >
         {DUST_STATE[grade]}
       </Text>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,7 @@
-import { ChakraProvider } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import theme from '@/styles/theme';
 import App from './App';
 import '@/styles/globalStyle.css';
 import '@/styles/reset.css';
@@ -14,9 +12,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <ReactQueryDevtools initialIsOpen={false} />
-      <ChakraProvider theme={theme}>
-        <App />
-      </ChakraProvider>
+      <App />
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/src/pages/Choice.tsx
+++ b/src/pages/Choice.tsx
@@ -24,8 +24,8 @@ const Choice = () => {
     <Flex
       height="100vh"
       direction="column"
-      justify="center"
-      align="center"
+      justifyContent="center"
+      alignItems="center"
       color="#ffffff"
       textAlign="center"
     >

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -1,13 +1,23 @@
-import { Flex, Box, Text, Center, Select } from '@chakra-ui/react';
+import { Flex, Box, Text, Center, Select, keyframes } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
 import { ChangeEvent, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { getSidoDustInfo } from '@/apis/dustInfo';
 import DustState from '@/components/common/DustState';
 import ProgressBar from '@/components/common/ProgressBar';
 import SidoRankList from '@/components/Ranking/SidoRankList';
-import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
+import theme from '@/styles/theme';
+import { DUST_GRADE, FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
 import { getDustAverageGrade } from '@/utils/dustGrade';
+
+const animationKeyframes = keyframes`
+  0% { background-position: 0 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+`;
+
+const animation = `${animationKeyframes} 6s ease infinite`;
 
 type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 
@@ -45,7 +55,14 @@ const Ranking = () => {
   );
 
   return (
-    <Box textAlign="center">
+    <Flex
+      direction="column"
+      as={motion.div}
+      animation={animation}
+      bgGradient={theme.backgroundColors[DUST_GRADE[dustAverageGrade]]}
+      textAlign="center"
+      backgroundSize="200% 200%"
+    >
       <Text
         as="h1"
         fontSize={{ base: 18, sm: 20, md: 24 }}
@@ -66,21 +83,21 @@ const Ranking = () => {
         {sidoDustInfo.dataTime} 기준
       </Text>
       <Box
-        w="80%"
+        width={{ base: '80%', sm: '80%', md: '60%', lg: '50%', xl: '40%' }}
         margin="0 auto"
         borderTopRadius={10}
         textAlign="center"
         bg="rgba(255, 255, 255, 0.6)"
         boxShadow="0 4px 30px rgba(0, 0, 0, 0.1)"
         backdropFilter="blur(7px)"
-        px={{ base: 3, sm: 6 }}
-        py={8}
+        px={{ base: 4, sm: 6 }}
+        py={{ base: 6, sm: 8 }}
       >
         <Text
           as="p"
           fontSize={{ base: 22, sm: 24, md: 28 }}
           fontWeight={700}
-          mb={4}
+          mb={{ base: 2, sm: 4 }}
         >
           {selectedSido}
         </Text>
@@ -105,6 +122,8 @@ const Ranking = () => {
         direction="column"
         justifyContent="center"
         alignItems="center"
+        width={{ base: '100%', sm: '100%', md: '70%', lg: '60%', xl: '50%' }}
+        margin="0 auto"
         borderRadius={20}
         bg="#f6f6f6"
         mb={20}
@@ -120,16 +139,17 @@ const Ranking = () => {
           py={3}
           borderRadius={25}
           color="#ffffff"
-          bg="#44b7f7"
+          bg={theme.colors[DUST_GRADE[dustAverageGrade]]}
         >
           지역별 미세 먼지 농도 순위
         </Text>
         <Select
-          color="#3a9cbd"
-          borderColor="#3a9cbd"
+          color="#4d4d4d"
+          borderColor="#7f7f7f"
           borderWidth={2}
           fontSize={{ base: 14, sm: 16 }}
           my={6}
+          _focus={{ borderColor: 'none' }}
           onChange={handleSortKeyChange}
         >
           <option>{FINE_DUST}</option>
@@ -137,7 +157,7 @@ const Ranking = () => {
         </Select>
         <SidoRankList sortType={selectedSortKey} />
       </Flex>
-    </Box>
+    </Flex>
   );
 };
 

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -84,7 +84,7 @@ const Ranking = () => {
       </Text>
       <Box
         maxWidth="37.5rem"
-        width={{ base: '80%', sm: '80%', md: '70%' }}
+        width={{ base: '80%', sm: '80%' }}
         margin="0 auto"
         borderTopRadius={10}
         textAlign="center"

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -83,7 +83,8 @@ const Ranking = () => {
         {sidoDustInfo.dataTime} 기준
       </Text>
       <Box
-        width={{ base: '80%', sm: '80%', md: '60%', lg: '50%', xl: '40%' }}
+        maxWidth="37.5rem"
+        width={{ base: '80%', sm: '80%', md: '70%' }}
         margin="0 auto"
         borderTopRadius={10}
         textAlign="center"
@@ -122,7 +123,8 @@ const Ranking = () => {
         direction="column"
         justifyContent="center"
         alignItems="center"
-        width={{ base: '100%', sm: '100%', md: '70%', lg: '60%', xl: '50%' }}
+        maxWidth="47.5rem"
+        width={{ base: '100%', sm: '100%' }}
         margin="0 auto"
         borderRadius={20}
         bg="#f6f6f6"

--- a/src/styles/globalStyle.css
+++ b/src/styles/globalStyle.css
@@ -8,11 +8,8 @@
 }
 
 #root {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  font-weight: 600;
+  background-color: #53caf2;
+  line-height: 1;
 }
 
 .circle-marker {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,16 @@
 import { extendTheme } from '@chakra-ui/react';
 
 const theme = extendTheme({
+  styles: {
+    global: () => ({
+      body: {
+        fontFamily: `'Pretendard Variable', Pretendard, -apple-system,
+        BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
+        'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji',
+        'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif`,
+      },
+    }),
+  },
   colors: {
     DANGER: '#e64746',
     BAD: '#fda60d',

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,13 +1,19 @@
 import { extendTheme } from '@chakra-ui/react';
 
 const theme = extendTheme({
-  styles: {
-    global: () => ({
-      body: {
-        bg: '#53caf2',
-        lineHeight: 1,
-      },
-    }),
+  colors: {
+    DANGER: '#e64746',
+    BAD: '#fda60d',
+    NORMAL: '#03c73c',
+    GOOD: '#30a2ff',
+  },
+  backgroundColors: {
+    DANGER:
+      'linear-gradient(77deg, rgba(255,255,180,1) 0%, rgba(246,104,103,1) 50%, rgba(230,71,70,1) 100%)',
+    BAD: 'linear-gradient(77deg, rgba(255,255,180,1) 0%, rgba(255,189,74,1) 50%, rgba(253,166,13,1) 100%)',
+    NORMAL:
+      'linear-gradient(77deg, rgba(255,255,180,1) 0%, rgba(110,226,144,1) 50%, rgba(3,199,60,1) 100%)',
+    GOOD: 'linear-gradient(77deg, rgba(255,255,180,1) 0%, rgba(83,202,242,1) 50%, rgba(48,162,255,1) 100%)',
   },
 });
 

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -10,5 +10,4 @@ export {
   COLOR_MARKER_MOUSE_OUT,
   ZINDEX_MARKER_MOUSE_OVER,
   ZINDEX_MARKER_MOUSE_OUT,
-  DUST_SCALE_COLOR,
 } from '@/utils/constants/map';

--- a/src/utils/constants/map.ts
+++ b/src/utils/constants/map.ts
@@ -6,10 +6,3 @@ export const COLOR_MARKER_MOUSE_OVER = 'yellow';
 export const COLOR_MARKER_MOUSE_OUT = 'white';
 export const ZINDEX_MARKER_MOUSE_OVER = '100';
 export const ZINDEX_MARKER_MOUSE_OUT = '0';
-
-export const DUST_SCALE_COLOR = {
-  DANGER: '#e64746',
-  BAD: '#fda60d',
-  NORMAL: '#03c73c',
-  GOOD: '#30a2ff',
-};


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #95 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 특정 지역의 미세먼지 농도에 따라 Ranking 페이지의 배경색 적용하기, 애니메이션 구현
- theme 상수를 이용해 기존 DUST_SCALE_COLOR 상수 제거
- 글로벌 스타일 수정 -> 불필요한 flex 스타일 제거
- 폰트 미적용 해결

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->


https://user-images.githubusercontent.com/76807107/237034585-ed818385-aefe-4625-bc37-673e318cf047.mp4




## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 배경색을 바꾸기 위해 글로벌 스타일을 고쳤습니다.... 다른 페이지 스타일도 수정해야해요.

## 질문 <!-- 궁금한 부분을 적어주세요 -->
- 챠크라 theme를 사용하는게 좋은지 아님 기존 상수를 활용하는게 좋은지?
