### PR TITLE
refactor: dust-forecast 페이지 모바일 UI 수정

### DIFF
--- a/src/components/DustForcast/CurrentDustInfo.tsx
+++ b/src/components/DustForcast/CurrentDustInfo.tsx
@@ -14,11 +14,11 @@ export const CurrentDustInfo = ({
 }: CurrentDustInfoProps) => {
   return (
     <Box flexGrow={1} borderX={{ base: 'none', sm: '1px solid #dfdfdf' }}>
-      <Text as="p" fontSize={{ base: 16, sm: 22 }} fontWeight={600} mb={2}>
+      <Text as="p" fontSize={{ base: 24, sm: 22 }} fontWeight={600} mb={2}>
         {kindOfDust}
       </Text>
       <Flex justifyContent="center" alignItems="center">
-        <Text as="p" fontSize={{ base: 24, sm: 48 }} fontWeight={800} mr={5}>
+        <Text as="p" fontSize={{ base: 30, sm: 48 }} fontWeight={800} mr={5}>
           {dustScale}
         </Text>
         <Box my={3}>

--- a/src/components/DustForcast/CurrentDustInfo.tsx
+++ b/src/components/DustForcast/CurrentDustInfo.tsx
@@ -13,12 +13,12 @@ export const CurrentDustInfo = ({
   dustGrade,
 }: CurrentDustInfoProps) => {
   return (
-    <Box flexGrow={1} borderRight="1px solid #dfdfdf">
-      <Text as="p" fontSize={22} fontWeight={600} mb={2}>
+    <Box flexGrow={1} borderX={{ base: 'none', sm: '1px solid #dfdfdf' }}>
+      <Text as="p" fontSize={{ base: 16, sm: 22 }} fontWeight={600} mb={2}>
         {kindOfDust}
       </Text>
       <Flex justifyContent="center" alignItems="center">
-        <Text as="p" fontSize={48} fontWeight={800} mr={5}>
+        <Text as="p" fontSize={{ base: 24, sm: 48 }} fontWeight={800} mr={5}>
           {dustScale}
         </Text>
         <Box my={3}>

--- a/src/components/DustForcast/CurrentDustInfo.tsx
+++ b/src/components/DustForcast/CurrentDustInfo.tsx
@@ -1,0 +1,31 @@
+import { Box, Text, Flex } from '@chakra-ui/react';
+import DustState from '../common/DustState';
+
+interface CurrentDustInfoProps {
+  kindOfDust: string;
+  dustScale: number;
+  dustGrade: number;
+}
+
+export const CurrentDustInfo = ({
+  kindOfDust,
+  dustScale,
+  dustGrade,
+}: CurrentDustInfoProps) => {
+  return (
+    <Box flexGrow={1} borderRight="1px solid #dfdfdf">
+      <Text as="p" fontSize={22} fontWeight={600} mb={2}>
+        {kindOfDust}
+      </Text>
+      <Flex justifyContent="center" alignItems="center">
+        <Text as="p" fontSize={48} fontWeight={800} mr={5}>
+          {dustScale}
+        </Text>
+        <Box my={3}>
+          <DustState dustGrade={dustGrade} />
+        </Box>
+      </Flex>
+    </Box>
+  );
+};
+export default CurrentDustInfo;

--- a/src/components/common/AlertBox.tsx
+++ b/src/components/common/AlertBox.tsx
@@ -23,7 +23,7 @@ const AlertBox = ({ title, description }: AlertBoxProps) => {
       py={6}
     >
       <AlertIcon boxSize={6} mb={3} />
-      <AlertTitle fontSize={18}>{title}</AlertTitle>
+      <AlertTitle fontSize={{ base: 16, sm: 18 }}>{title}</AlertTitle>
       <AlertDescription fontSize={16} fontWeight={400}>
         {description}
       </AlertDescription>

--- a/src/pages/DustForecast.tsx
+++ b/src/pages/DustForecast.tsx
@@ -62,28 +62,29 @@ const DustForecast = () => {
         </Flex>
 
         <Box mb={14}>
-          {isLargerThan480 ? (
-            <Flex direction="column" alignItems="center" mb={4}>
-              <Text as="p" fontSize={22} fontWeight={600} textAlign="center">
-                시간별 {FINE_DUST} 농도
-              </Text>
-              <Text
-                as="p"
-                fontSize={16}
-                fontWeight={400}
-                textAlign="center"
-                mt={2}
-                mb={4}
-              >
-                {dataTime.split(' ')[0]}
-              </Text>
-              <DustLevel direction="row" />
-            </Flex>
-          ) : (
-            <Flex direction="column" alignItems="center" mt={10}>
-              <DustLevel direction="row" />
-            </Flex>
-          )}
+          <Flex direction="column" alignItems="center" mb={4}>
+            <Text
+              display={isLargerThan480 ? 'block' : 'none'}
+              as="p"
+              fontSize={22}
+              fontWeight={600}
+              textAlign="center"
+            >
+              시간별 {FINE_DUST} 농도
+            </Text>
+            <Text
+              display={isLargerThan480 ? 'block' : 'none'}
+              as="p"
+              fontSize={16}
+              fontWeight={400}
+              textAlign="center"
+              mt={2}
+              mb={4}
+            >
+              {dataTime.split(' ')[0]}
+            </Text>
+            <DustLevel direction="row" />
+          </Flex>
           <DustChart cityName={cityName} />
         </Box>
         <ForcastInfo cityName={cityName} />

--- a/src/pages/DustForecast.tsx
+++ b/src/pages/DustForecast.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, Flex } from '@chakra-ui/react';
+import { Box, Text, Flex, useMediaQuery } from '@chakra-ui/react';
 import { useLocation } from 'react-router-dom';
 import DustLevel from '@/components/common/DustLevel';
 import DustState from '@/components/common/DustState';
@@ -6,6 +6,7 @@ import DustChart from '@/components/DustForcast/DustChart';
 import ForcastInfo from '@/components/DustForcast/ForcastInfo';
 import type { CityDustInfo } from '@/types/dust';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
+import CurrentDustInfo from '@/components/DustForcast/CurrentDustInfo';
 
 const DustForecast = () => {
   const location = useLocation();
@@ -18,55 +19,57 @@ const DustForecast = () => {
     dataTime,
   }: CityDustInfo = location.state;
 
+  const [isLargerThan480] = useMediaQuery('(min-width: 480px)');
+
   return (
     <Box textAlign="center">
       <Text
         as="h1"
-        fontSize={30}
+        fontSize={{ base: 32, sm: 30 }}
         fontWeight={600}
         color="#ffffff"
         mt={20}
         mb={4}
       >
-        {cityName}의 {FINE_DUST} 농도는 다음과 같습니다.
+        {isLargerThan480
+          ? `${cityName}의 ${FINE_DUST} 농도는 다음과 같습니다.`
+          : `${cityName}`}
       </Text>
-      <Text as="p" fontSize={20} fontWeight={300} color="#ffffff" mb={6}>
+      <Text
+        as="p"
+        fontSize={{ base: 16, sm: 20 }}
+        fontWeight={300}
+        color="#ffffff"
+        mb={6}
+      >
         {dataTime} 기준
       </Text>
       <Box borderRadius={10} mb={20} py={10} px={8} bg="#ffffff">
-        <Flex
-          alignItems="center"
-          pb={10}
-          mb={14}
-          borderBottom="1px solid #dfdfdf"
-        >
-          <Box flexGrow={1} borderRight="1px solid #dfdfdf">
-            <Text as="p" fontSize={22} fontWeight={600} mb={2}>
-              {FINE_DUST}
-            </Text>
-            <Flex justifyContent="center" alignItems="center">
-              <Text as="p" fontSize={48} fontWeight={800} mr={5}>
-                {fineDustScale}
-              </Text>
-              <Box my={3}>
-                <DustState dustGrade={fineDustGrade} />
-              </Box>
-            </Flex>
-          </Box>
-          <Box flexGrow={1}>
-            <Text as="p" fontSize={22} fontWeight={600} mb={2}>
-              {ULTRA_FINE_DUST}
-            </Text>
-            <Flex justifyContent="center" alignItems="center">
-              <Text as="p" fontSize={48} fontWeight={800} mr={5}>
-                {ultraFineDustScale}
-              </Text>
-              <Box my={3}>
-                <DustState dustGrade={ultraFineDustGrade} />
-              </Box>
-            </Flex>
-          </Box>
-        </Flex>
+        {isLargerThan480 ? (
+          <Flex
+            alignItems="center"
+            pb={10}
+            mb={14}
+            borderBottom="1px solid #dfdfdf"
+          >
+            <CurrentDustInfo
+              kindOfDust={FINE_DUST}
+              dustScale={fineDustScale}
+              dustGrade={fineDustGrade}
+            />
+            <CurrentDustInfo
+              kindOfDust={ULTRA_FINE_DUST}
+              dustScale={ultraFineDustScale}
+              dustGrade={ultraFineDustGrade}
+            />
+          </Flex>
+        ) : (
+          <CurrentDustInfo
+            kindOfDust={FINE_DUST}
+            dustScale={fineDustScale}
+            dustGrade={fineDustGrade}
+          />
+        )}
         <Box mb={14}>
           <Flex direction="column" alignItems="center" mb={4}>
             <Text as="p" fontSize={22} fontWeight={600} textAlign="center">

--- a/src/pages/DustForecast.tsx
+++ b/src/pages/DustForecast.tsx
@@ -31,7 +31,7 @@ const DustForecast = () => {
         mb={4}
       >
         {cityName +
-          (isLargerThan480 ? `의 ${FINE_DUST} 농도는 다음과 같습니다.` : '')}
+          (isLargerThan480 ? `의 ${FINE_DUST} 농도는 다음과 같습니다.` : null)}
       </Text>
       <Text
         as="p"

--- a/src/pages/DustForecast.tsx
+++ b/src/pages/DustForecast.tsx
@@ -44,31 +44,24 @@ const DustForecast = () => {
         {dataTime} 기준
       </Text>
       <Box borderRadius={10} mb={20} py={10} px={8} bg="#ffffff">
-        {isLargerThan480 ? (
-          <Flex
-            alignItems="center"
-            pb={10}
-            mb={14}
-            borderBottom="1px solid #dfdfdf"
-          >
-            <CurrentDustInfo
-              kindOfDust={FINE_DUST}
-              dustScale={fineDustScale}
-              dustGrade={fineDustGrade}
-            />
-            <CurrentDustInfo
-              kindOfDust={ULTRA_FINE_DUST}
-              dustScale={ultraFineDustScale}
-              dustGrade={ultraFineDustGrade}
-            />
-          </Flex>
-        ) : (
+        <Flex
+          alignItems="center"
+          pb={10}
+          mb={14}
+          borderBottom="1px solid #dfdfdf"
+        >
           <CurrentDustInfo
             kindOfDust={FINE_DUST}
             dustScale={fineDustScale}
             dustGrade={fineDustGrade}
           />
-        )}
+          <CurrentDustInfo
+            kindOfDust={ULTRA_FINE_DUST}
+            dustScale={ultraFineDustScale}
+            dustGrade={ultraFineDustGrade}
+          />
+        </Flex>
+
         <Box mb={14}>
           {isLargerThan480 ? (
             <Flex direction="column" alignItems="center" mb={4}>

--- a/src/pages/DustForecast.tsx
+++ b/src/pages/DustForecast.tsx
@@ -1,7 +1,6 @@
 import { Box, Text, Flex, useMediaQuery } from '@chakra-ui/react';
 import { useLocation } from 'react-router-dom';
 import DustLevel from '@/components/common/DustLevel';
-import DustState from '@/components/common/DustState';
 import DustChart from '@/components/DustForcast/DustChart';
 import ForcastInfo from '@/components/DustForcast/ForcastInfo';
 import type { CityDustInfo } from '@/types/dust';
@@ -22,10 +21,10 @@ const DustForecast = () => {
   const [isLargerThan480] = useMediaQuery('(min-width: 480px)');
 
   return (
-    <Box textAlign="center">
+    <Flex direction="column" textAlign="center">
       <Text
         as="h1"
-        fontSize={{ base: 32, sm: 30 }}
+        fontSize={{ base: 32, sm: 28 }}
         fontWeight={600}
         color="#ffffff"
         mt={20}
@@ -71,27 +70,33 @@ const DustForecast = () => {
           />
         )}
         <Box mb={14}>
-          <Flex direction="column" alignItems="center" mb={4}>
-            <Text as="p" fontSize={22} fontWeight={600} textAlign="center">
-              시간별 {FINE_DUST} 농도
-            </Text>
-            <Text
-              as="p"
-              fontSize={16}
-              fontWeight={400}
-              textAlign="center"
-              mt={2}
-              mb={4}
-            >
-              {dataTime.split(' ')[0]}
-            </Text>
-            <DustLevel direction="row" />
-          </Flex>
+          {isLargerThan480 ? (
+            <Flex direction="column" alignItems="center" mb={4}>
+              <Text as="p" fontSize={22} fontWeight={600} textAlign="center">
+                시간별 {FINE_DUST} 농도
+              </Text>
+              <Text
+                as="p"
+                fontSize={16}
+                fontWeight={400}
+                textAlign="center"
+                mt={2}
+                mb={4}
+              >
+                {dataTime.split(' ')[0]}
+              </Text>
+              <DustLevel direction="row" />
+            </Flex>
+          ) : (
+            <Flex direction="column" alignItems="center" mt={10}>
+              <DustLevel direction="row" />
+            </Flex>
+          )}
           <DustChart cityName={cityName} />
         </Box>
         <ForcastInfo cityName={cityName} />
       </Box>
-    </Box>
+    </Flex>
   );
 };
 

--- a/src/pages/DustForecast.tsx
+++ b/src/pages/DustForecast.tsx
@@ -30,9 +30,8 @@ const DustForecast = () => {
         mt={20}
         mb={4}
       >
-        {isLargerThan480
-          ? `${cityName}의 ${FINE_DUST} 농도는 다음과 같습니다.`
-          : `${cityName}`}
+        {cityName +
+          (isLargerThan480 ? `의 ${FINE_DUST} 농도는 다음과 같습니다.` : '')}
       </Text>
       <Text
         as="p"


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #88 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 모바일 환경에서의 화면을 구성합니다.
## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
[chrome-capture-2023-4-9.webm](https://user-images.githubusercontent.com/12118892/236880116-1b093740-dd64-41a7-8b56-f9420de4a930.webm)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 화면 축소 시 'OOO의 미세먼지 농도는 다음과 같습니다.' 가 OOO 으로 동네 이름만 표기됩니다.
- 화면 축소 시 '시간별 미세먼지 농도 2023-05-09' 메시지가 사라집니다. 
- 화면 축소 시 일부 메시지가 어색하게 줄 바꿈 되던 현상을 수정했습니다. (폰트 크기 수정)
- 기존 페이지에서 2번 이상 반복되던 부분을 별도의 컴포넌트로 분리했습니다.
- 먼지 농도에 따른 배경색 변경은 현재 올라와있는 다른 PR이 머지되면 반영할 예정입니다.
## 질문 <!-- 궁금한 부분을 적어주세요 -->
- 원 페이지가 정보의 양이 많지 않고 차트의 경우도 가로 스크롤이 적용 되어 있어서 어느 부분에서 UI를 변경해야 할지 의견을 듣고 싶습니다. 화면이 작아지는 만큼 정보를 간결하고 한 눈에 보기 편하게 UI를 구성하면 좋을 것 같다고 생각중입니다.