### PR TITLE
feat: ranking 화면에서 sido를 변경할 수 있도록 수정.

### DIFF
--- a/src/components/Ranking/SelectList.tsx
+++ b/src/components/Ranking/SelectList.tsx
@@ -1,0 +1,27 @@
+import { Select } from '@chakra-ui/react';
+import { ChangeEvent } from 'react';
+
+interface SidoListProps {
+  handleChange: (e: ChangeEvent<HTMLSelectElement>) => void;
+  selectOptions: string[];
+}
+
+export const SidoList = ({ handleChange, selectOptions }: SidoListProps) => {
+  return (
+    <Select
+      color="#4d4d4d"
+      borderColor="#7f7f7f"
+      borderWidth={2}
+      fontSize={{ base: 14, sm: 16 }}
+      my={6}
+      _focus={{ borderColor: 'none' }}
+      onChange={handleChange}
+    >
+      {selectOptions.map((selectOption) => {
+        return <option key={selectOption}>{selectOption}</option>;
+      })}
+    </Select>
+  );
+};
+
+export default SidoList;

--- a/src/components/Ranking/SelectList.tsx
+++ b/src/components/Ranking/SelectList.tsx
@@ -1,12 +1,17 @@
 import { Select } from '@chakra-ui/react';
 import { ChangeEvent } from 'react';
 
-interface SidoListProps {
+interface SelectListProps {
   handleChange: (e: ChangeEvent<HTMLSelectElement>) => void;
   selectOptions: string[];
+  defaultValue: string;
 }
 
-export const SidoList = ({ handleChange, selectOptions }: SidoListProps) => {
+export const SelectList = ({
+  handleChange,
+  selectOptions,
+  defaultValue,
+}: SelectListProps) => {
   return (
     <Select
       color="#4d4d4d"
@@ -16,12 +21,15 @@ export const SidoList = ({ handleChange, selectOptions }: SidoListProps) => {
       mt={6}
       _focus={{ borderColor: 'none' }}
       onChange={handleChange}
+      value={defaultValue}
     >
       {selectOptions.map((selectOption) => (
-        <option key={selectOption}>{selectOption}</option>
+        <option value={selectOption} key={selectOption}>
+          {selectOption}
+        </option>
       ))}
     </Select>
   );
 };
 
-export default SidoList;
+export default SelectList;

--- a/src/components/Ranking/SelectList.tsx
+++ b/src/components/Ranking/SelectList.tsx
@@ -13,7 +13,7 @@ export const SidoList = ({ handleChange, selectOptions }: SidoListProps) => {
       borderColor="#7f7f7f"
       borderWidth={2}
       fontSize={{ base: 14, sm: 16 }}
-      my={6}
+      mt={6}
       _focus={{ borderColor: 'none' }}
       onChange={handleChange}
     >

--- a/src/components/Ranking/SelectList.tsx
+++ b/src/components/Ranking/SelectList.tsx
@@ -17,9 +17,9 @@ export const SidoList = ({ handleChange, selectOptions }: SidoListProps) => {
       _focus={{ borderColor: 'none' }}
       onChange={handleChange}
     >
-      {selectOptions.map((selectOption) => {
-        return <option key={selectOption}>{selectOption}</option>;
-      })}
+      {selectOptions.map((selectOption) => (
+        <option key={selectOption}>{selectOption}</option>
+      ))}
     </Select>
   );
 };

--- a/src/pages/Choice.tsx
+++ b/src/pages/Choice.tsx
@@ -9,7 +9,7 @@ const Choice = () => {
   const [place, setPlace] = useState(SIDO_GROUP[0].sidoName);
 
   const handleResultPageNavigate = () => {
-    navigate(ROUTE.RANKING, { state: place });
+    navigate(`${ROUTE.RANKING}/?place=${encodeURIComponent(place)}`);
   };
 
   const handleMapPageNavigate = () => {

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -1,15 +1,7 @@
-import {
-  Flex,
-  Box,
-  Text,
-  Center,
-  Select,
-  keyframes,
-  Spinner,
-} from '@chakra-ui/react';
+import { Flex, Box, Text, Center, keyframes, Spinner } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { getSidoDustInfo } from '@/apis/dustInfo';
 import DustState from '@/components/common/DustState';
@@ -38,7 +30,8 @@ type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 const Ranking = () => {
   const { state: initSelectedSido } = useLocation();
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
-  const [selectedSido, setSelectedSido] = useState(initSelectedSido);
+  const [selectedSido, setSelectedSido] = useState<string>(initSelectedSido);
+  const [dustAverageGrade, setDustAverageGrade] = useState(0);
   const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
   const sidoNames = [
     selectedSido,
@@ -68,18 +61,15 @@ const Ranking = () => {
     setSelectedSido(target.value);
   };
 
-  if (!sidoDustInfo) {
-    return (
-      <Center height="100vh" fontSize={28} fontWeight={100} color="#ffffff">
-        <Spinner />
-      </Center>
-    );
-  }
-
-  const dustAverageGrade = getDustAverageGrade(
-    sidoDustInfo.fineDustGrade,
-    sidoDustInfo.ultraFineDustGrade
-  );
+  useEffect(() => {
+    sidoDustInfo &&
+      setDustAverageGrade(
+        getDustAverageGrade(
+          sidoDustInfo.fineDustGrade,
+          sidoDustInfo.ultraFineDustGrade
+        )
+      );
+  }, [sidoDustInfo]);
 
   return (
     <Flex
@@ -108,7 +98,7 @@ const Ranking = () => {
         color="#ffffff"
         mb={6}
       >
-        {sidoDustInfo.dataTime} 기준
+        {sidoDustInfo ? sidoDustInfo.dataTime : '0000-00-00 00:00'} 기준
       </Text>
       <Box
         maxWidth="37.5rem"
@@ -136,16 +126,22 @@ const Ranking = () => {
         <Center my={5}>
           <DustState dustGrade={dustAverageGrade} />
         </Center>
-        <ProgressBar
-          kindOfDust={FINE_DUST}
-          scale={sidoDustInfo.fineDustScale}
-          grade={sidoDustInfo.fineDustGrade}
-        />
-        <ProgressBar
-          kindOfDust={ULTRA_FINE_DUST}
-          scale={sidoDustInfo.ultraFineDustScale}
-          grade={sidoDustInfo.ultraFineDustGrade}
-        />
+        {sidoDustInfo ? (
+          <>
+            <ProgressBar
+              kindOfDust={FINE_DUST}
+              scale={sidoDustInfo.fineDustScale}
+              grade={sidoDustInfo.fineDustGrade}
+            />
+            <ProgressBar
+              kindOfDust={ULTRA_FINE_DUST}
+              scale={sidoDustInfo.ultraFineDustScale}
+              grade={sidoDustInfo.ultraFineDustGrade}
+            />
+          </>
+        ) : (
+          <Spinner />
+        )}
       </Box>
       <Flex
         direction="column"

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -40,7 +40,12 @@ const Ranking = () => {
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
   const [selectedSido, setSelectedSido] = useState(initSelectedSido);
   const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
-  const sidoNames = SIDO_GROUP.map((sido) => sido.sidoName);
+  const sidoNames = [
+    selectedSido,
+    ...SIDO_GROUP.map((sido) => sido.sidoName).filter(
+      (sidoName) => sidoName !== selectedSido
+    ),
+  ];
 
   const { data: sidoDustInfo } = useQuery(
     ['sido-dust-info', selectedSido],

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -15,7 +15,7 @@ import {
   SIDO_GROUP,
 } from '@/utils/constants';
 import { getDustAverageGrade } from '@/utils/dustGrade';
-import SidoList from '@/components/Ranking/SelectList';
+import SelectList from '@/components/Ranking/SelectList';
 
 const animationKeyframes = keyframes`
   0% { background-position: 0 50%; }
@@ -35,12 +35,7 @@ const Ranking = () => {
   const [selectedSido, setSelectedSido] = useState(place);
   const [dustAverageGrade, setDustAverageGrade] = useState(0);
   const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
-  const sidoNames = [
-    selectedSido,
-    ...SIDO_GROUP.map((sido) => sido.sidoName).filter(
-      (sidoName) => sidoName !== selectedSido
-    ),
-  ];
+  const sidoNames = SIDO_GROUP.map((sido) => sido.sidoName);
 
   const { data: sidoDustInfo } = useQuery(
     ['sido-dust-info', selectedSido],
@@ -171,13 +166,15 @@ const Ranking = () => {
         >
           지역별 미세 먼지 농도 순위
         </Text>
-        <SidoList
+        <SelectList
           handleChange={handleSelectedSidoChange}
           selectOptions={sidoNames}
+          defaultValue={selectedSido}
         />
-        <SidoList
+        <SelectList
           handleChange={handleSortKeyChange}
           selectOptions={kindOfDust}
+          defaultValue={selectedSortKey}
         />
         <SidoRankList sortType={selectedSortKey} />
       </Flex>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -28,9 +28,11 @@ const animation = `${animationKeyframes} 6s ease infinite`;
 type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 
 const Ranking = () => {
-  const { state: initSelectedSido } = useLocation();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(decodeURIComponent(location.search));
+  const place = searchParams.get('place') || '서울';
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
-  const [selectedSido, setSelectedSido] = useState<string>(initSelectedSido);
+  const [selectedSido, setSelectedSido] = useState(place);
   const [dustAverageGrade, setDustAverageGrade] = useState(0);
   const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
   const sidoNames = [

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -10,14 +10,13 @@ import {
 } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
-import { ChangeEvent, useState, Suspense } from 'react';
+import { ChangeEvent, useState, useEffect, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useLocation } from 'react-router-dom';
 import { getSidoDustInfo } from '@/apis/dustInfo';
 import DustState from '@/components/common/DustState';
 import ErrorFallback from '@/components/common/Fallback/ErrorFallback';
 import ProgressBar from '@/components/common/ProgressBar';
-import SidoRankList from '@/components/Ranking/SidoRankList';
 import theme from '@/styles/theme';
 import {
   DUST_GRADE,

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -16,8 +16,14 @@ import DustState from '@/components/common/DustState';
 import ProgressBar from '@/components/common/ProgressBar';
 import SidoRankList from '@/components/Ranking/SidoRankList';
 import theme from '@/styles/theme';
-import { DUST_GRADE, FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
+import {
+  DUST_GRADE,
+  FINE_DUST,
+  ULTRA_FINE_DUST,
+  SIDO_GROUP,
+} from '@/utils/constants';
 import { getDustAverageGrade } from '@/utils/dustGrade';
+import SidoList from '@/components/Ranking/SelectList';
 
 const animationKeyframes = keyframes`
   0% { background-position: 0 50%; }
@@ -30,8 +36,11 @@ const animation = `${animationKeyframes} 6s ease infinite`;
 type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 
 const Ranking = () => {
-  const { state: selectedSido } = useLocation();
+  const { state: initSelectedSido } = useLocation();
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
+  const [selectedSido, setSelectedSido] = useState(initSelectedSido);
+  const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
+  const sidoNames = SIDO_GROUP.map((sido) => sido.sidoName);
 
   const { data: sidoDustInfo } = useQuery(
     ['sido-dust-info', selectedSido],
@@ -47,6 +56,11 @@ const Ranking = () => {
     target.value === FINE_DUST
       ? setSelectedSortKey(FINE_DUST)
       : setSelectedSortKey(ULTRA_FINE_DUST);
+  };
+
+  const handleChangeSelectedSido = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { target } = e;
+    setSelectedSido(target.value);
   };
 
   if (!sidoDustInfo) {
@@ -154,18 +168,14 @@ const Ranking = () => {
         >
           지역별 미세 먼지 농도 순위
         </Text>
-        <Select
-          color="#4d4d4d"
-          borderColor="#7f7f7f"
-          borderWidth={2}
-          fontSize={{ base: 14, sm: 16 }}
-          my={6}
-          _focus={{ borderColor: 'none' }}
-          onChange={handleSortKeyChange}
-        >
-          <option>{FINE_DUST}</option>
-          <option>{ULTRA_FINE_DUST}</option>
-        </Select>
+        <SidoList
+          handleChange={handleSortKeyChange}
+          selectOptions={kindOfDust}
+        />
+        <SidoList
+          handleChange={handleChangeSelectedSido}
+          selectOptions={sidoNames}
+        />
         <SidoRankList sortType={selectedSortKey} />
       </Flex>
     </Flex>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -56,7 +56,7 @@ const Ranking = () => {
       : setSelectedSortKey(ULTRA_FINE_DUST);
   };
 
-  const handleChangeSelectedSido = (e: ChangeEvent<HTMLSelectElement>) => {
+  const handleSelectedSidoChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const { target } = e;
     setSelectedSido(target.value);
   };
@@ -170,7 +170,7 @@ const Ranking = () => {
           지역별 미세 먼지 농도 순위
         </Text>
         <SidoList
-          handleChange={handleChangeSelectedSido}
+          handleChange={handleSelectedSidoChange}
           selectOptions={sidoNames}
         />
         <SidoList

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -170,12 +170,12 @@ const Ranking = () => {
           지역별 미세 먼지 농도 순위
         </Text>
         <SidoList
-          handleChange={handleSortKeyChange}
-          selectOptions={kindOfDust}
-        />
-        <SidoList
           handleChange={handleChangeSelectedSido}
           selectOptions={sidoNames}
+        />
+        <SidoList
+          handleChange={handleSortKeyChange}
+          selectOptions={kindOfDust}
         />
         <SidoRankList sortType={selectedSortKey} />
       </Flex>


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #104 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 이제 ranking 화면에서도 선택했던 sido를 변경할 수 있습니다.
- sido를 변경시 spinner가 전체 화면 크기로 나오던 현상을 수정하여 더 자연스럽게 변화하도록 하였습니다.

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![chrome-capture-2023-4-16](https://github.com/tooooo1/dust-rating/assets/12118892/b611db6d-aa23-4196-8820-5a83858b4b08)


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 일반 변수로 사용되던 'dustAverageGrade'를 state로 변경하였습니다.
- select를 구현하는 부분이 2번 이상 반복되어서 SelectList.tsx로 분리하였습니다.
- 동일 화면에서 보여지는 정보만 바뀌는 만큼 사용자가 최대한 이질감을 안느꼈으면 좋겠다 라고 생각했습니다.(flickering 같은) 좀 더 개선되었으면 좋겠다 하는 부분에 대해서 말씀해주세요!
## 질문 <!-- 궁금한 부분을 적어주세요 -->
- 화면의 자연스러운 변화를 위하여 state와 useEffect를 추가하였는데 더 좋은 방법이 있는지 궁금합니다.
- useLocation()로 받아오는 initSelectedSido는 Ranking페이지를 처음 로드할 때 말고는 사용되지 않습니다. 제거할 수 있는 방법이 있을까요? props로 받아오는 방법을 생각해보아야 할까요?
- 사용자가 선택한 sido를 select option 중 가장 최상단에 오게 하려다보니 sidoNames를 정의하는 표현식이 깔끔하지 않아진것 같습니다. 더 좋은 표현방법이 있을까요?