### PR TITLE
feat: DustForecast 페이지에 특정 지역의 미세먼지 농도에 따른 배경색 적용

### DIFF
--- a/src/components/DustForcast/CurrentDustInfo.tsx
+++ b/src/components/DustForcast/CurrentDustInfo.tsx
@@ -14,7 +14,7 @@ export const CurrentDustInfo = ({
 }: CurrentDustInfoProps) => {
   return (
     <Box flexGrow={1} borderX={{ base: 'none', sm: '1px solid #dfdfdf' }}>
-      <Text as="p" fontSize={{ base: 24, sm: 22 }} fontWeight={600} mb={2}>
+      <Text as="p" fontSize={{ base: 20, sm: 22 }} fontWeight={600} mb={2}>
         {kindOfDust}
       </Text>
       <Flex justifyContent="center" alignItems="center">

--- a/src/pages/DustForecast.tsx
+++ b/src/pages/DustForecast.tsx
@@ -1,11 +1,21 @@
-import { Box, Text, Flex, useMediaQuery } from '@chakra-ui/react';
+import { Box, Text, Flex, keyframes, useMediaQuery } from '@chakra-ui/react';
+import { motion } from 'framer-motion';
 import { useLocation } from 'react-router-dom';
 import DustLevel from '@/components/common/DustLevel';
+import CurrentDustInfo from '@/components/DustForcast/CurrentDustInfo';
 import DustChart from '@/components/DustForcast/DustChart';
 import ForcastInfo from '@/components/DustForcast/ForcastInfo';
+import theme from '@/styles/theme';
 import type { CityDustInfo } from '@/types/dust';
-import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
-import CurrentDustInfo from '@/components/DustForcast/CurrentDustInfo';
+import { DUST_GRADE, FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
+import { getDustAverageGrade } from '@/utils/dustGrade';
+
+const animationKeyframes = keyframes`
+  0% { background-position: 0 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+`;
+const animation = `${animationKeyframes} 6s ease infinite`;
 
 const DustForecast = () => {
   const location = useLocation();
@@ -20,29 +30,51 @@ const DustForecast = () => {
 
   const [isLargerThan480] = useMediaQuery('(min-width: 480px)');
 
+  const dustAverageGrade = getDustAverageGrade(
+    fineDustGrade,
+    ultraFineDustGrade
+  );
+
   return (
-    <Flex direction="column" textAlign="center">
+    <Flex
+      direction="column"
+      minHeight="100vh"
+      as={motion.div}
+      animation={animation}
+      bgGradient={theme.backgroundColors[DUST_GRADE[dustAverageGrade]]}
+      textAlign="center"
+      backgroundSize="200% 200%"
+    >
       <Text
         as="h1"
-        fontSize={{ base: 32, sm: 28 }}
+        fontSize={{ base: 18, sm: 20, md: 24 }}
         fontWeight={600}
         color="#ffffff"
         mt={20}
-        mb={4}
+        mb={{ base: 2, sm: 3, md: 4 }}
       >
         {cityName}
         {isLargerThan480 && `의 ${FINE_DUST} 농도는 다음과 같습니다.`}
       </Text>
       <Text
         as="p"
-        fontSize={{ base: 16, sm: 20 }}
+        fontSize={{ base: 14, sm: 18, md: 20 }}
         fontWeight={300}
         color="#ffffff"
         mb={6}
       >
         {dataTime} 기준
       </Text>
-      <Box borderRadius={10} mb={20} py={10} px={8} bg="#ffffff">
+      <Box
+        maxWidth="47.5rem"
+        width={{ base: '100%', sm: '100%' }}
+        margin="0 auto"
+        borderRadius={10}
+        bg="#ffffff"
+        mb={20}
+        px={{ base: 6, sm: 14, md: 20 }}
+        py={16}
+      >
         <Flex
           alignItems="center"
           pb={10}
@@ -60,7 +92,6 @@ const DustForecast = () => {
             dustGrade={ultraFineDustGrade}
           />
         </Flex>
-
         <Box mb={14}>
           <Flex direction="column" alignItems="center" mb={4}>
             <Text
@@ -69,19 +100,9 @@ const DustForecast = () => {
               fontSize={22}
               fontWeight={600}
               textAlign="center"
-            >
-              시간별 {FINE_DUST} 농도
-            </Text>
-            <Text
-              display={isLargerThan480 ? 'block' : 'none'}
-              as="p"
-              fontSize={16}
-              fontWeight={400}
-              textAlign="center"
-              mt={2}
               mb={4}
             >
-              {dataTime.split(' ')[0]}
+              시간별 {FINE_DUST} 농도
             </Text>
             <DustLevel direction="row" />
           </Flex>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -64,8 +64,8 @@ const Ranking = () => {
 
   return (
     <Flex
-      minHeight="100vh"
       direction="column"
+      minHeight="100vh"
       as={motion.div}
       animation={animation}
       bgGradient={theme.backgroundColors[DUST_GRADE[dustAverageGrade]]}

--- a/src/utils/formaters.ts
+++ b/src/utils/formaters.ts
@@ -3,6 +3,15 @@ export const getTodayDate = () => {
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
   const day = date.getDate();
+  const hour = date.getHours();
+
+  if (hour === 0) {
+    const yesterday = new Date(date.setDate(date.getDate() - 1)).getDate();
+
+    return `${year}-${month < 10 ? '0' + month : month}-${
+      yesterday < 10 ? '0' + yesterday : yesterday
+    }`;
+  }
 
   return `${year}-${month < 10 ? '0' + month : month}-${
     day < 10 ? '0' + day : day


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #115 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 특정 지역의 미세먼지 농도에 따른 배경색 적용
- 반응형 구현
- 24시(0시)일 때, 어제 날짜 데이터 보여주기

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

https://github.com/tooooo1/dust-rating/assets/76807107/0be55235-81c8-47fb-8967-ea352eccf6ae


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 차트 데이터의 경우, 특정 시각에 대한 데이터를 불러오는 것이 아니라 하루치 데이터를 가져오는 방식이라 다음과 같이 데이터가 넘어와요.
- 즉, 24시가 되는 경우, 0시 데이터가 없어서 기존에는 차트 데이터가 비워져 있었는데 이를 해결했어요.
- 예를 들면 16일 24시 -> 17시 0시 데이터가 없음.

![image](https://github.com/tooooo1/dust-rating/assets/76807107/c566263a-cc0e-4b1a-8fe3-ed371d2e29d4)


## 질문 <!-- 궁금한 부분을 적어주세요 -->
