### PR TITLE
refactor: ranking 페이지 쿼리 변경, 스타일 변경

### DIFF
--- a/src/components/Ranking/SelectList.tsx
+++ b/src/components/Ranking/SelectList.tsx
@@ -18,6 +18,7 @@ export const SelectList = ({
       borderColor="#7f7f7f"
       borderWidth={2}
       fontSize={{ base: 14, sm: 16 }}
+      textAlign="center"
       mt={6}
       _focus={{ borderColor: 'none' }}
       onChange={handleChange}

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -106,15 +106,17 @@ const Ranking = () => {
         px={{ base: 4, sm: 6 }}
         py={{ base: 6, sm: 8 }}
       >
+        <SelectList
+          handleChange={handleSelectedSidoChange}
+          selectOptions={sidoNames}
+          defaultValue={selectedSido}
+        />
         <Text
-          as="p"
-          fontSize={{ base: 22, sm: 24, md: 28 }}
-          fontWeight={700}
-          mb={{ base: 2, sm: 4 }}
+          as="div"
+          mt="1rem"
+          fontSize={{ base: 16, sm: 18 }}
+          color="#4d4d4d"
         >
-          {selectedSido}
-        </Text>
-        <Text as="span" fontSize={{ base: 16, sm: 18 }} color="#4d4d4d">
           현재의 대기질 지수는
         </Text>
         <Center my={5}>
@@ -162,11 +164,6 @@ const Ranking = () => {
         >
           지역별 미세 먼지 농도 순위
         </Text>
-        <SelectList
-          handleChange={handleSelectedSidoChange}
-          selectOptions={sidoNames}
-          defaultValue={selectedSido}
-        />
         <SelectList
           handleChange={handleSortKeyChange}
           selectOptions={kindOfDust}

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -2,7 +2,7 @@ import { Flex, Box, Text, Center, keyframes, Skeleton } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { ChangeEvent, useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { getSidoDustInfo } from '@/apis/dustInfo';
 import { AsyncBoundary, DustFigureBar, DustState } from '@/components/common';
 import { SelectList, SidoRankList } from '@/components/Ranking';
@@ -26,9 +26,8 @@ const animation = `${animationKeyframes} 6s ease infinite`;
 type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 
 const Ranking = () => {
-  const location = useLocation();
-  const searchParams = new URLSearchParams(decodeURIComponent(location.search));
-  const place = searchParams.get('place') || '서울';
+  const [serachParams, setSearchParams] = useSearchParams();
+  const place = serachParams.get('place') || '서울';
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
   const [selectedSido, setSelectedSido] = useState(place);
   const [dustAverageGrade, setDustAverageGrade] = useState(0);
@@ -51,8 +50,9 @@ const Ranking = () => {
   };
 
   const handleSelectedSidoChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const { target } = e;
-    setSelectedSido(target.value);
+    const nextSido = e.target.value;
+    setSearchParams({ place: nextSido }, { replace: true });
+    setSelectedSido(nextSido);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #135 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- ranking 페이지에서 선택한 도시가 변경되면 쿼리도 변경됩니다.

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
[chrome-capture-2023-4-20.webm](https://github.com/tooooo1/dust-rating/assets/12118892/068683e4-b17e-44d9-91b8-91dda016ed31)

캡쳐에 주소창, select option들이 안나오네요..변경된 ui 확인용으로 봐주세요.

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- sido를 변경하고 뒤로 가기를 수행하면 쿼리는 이전 것으로 변경되지만 화면엔 변화가 없어서 replace 옵션을 수정하여 뒤로가기를 실행했을 때 이전 페이지로 가도록 해놓았습니다.
```
setSearchParams({ place: nextSido }, { replace: true });
```
## 질문 <!-- 궁금한 부분을 적어주세요 -->
