### PR TITLE
refactor: 미세먼지 기준 변경, 불필요한 함수 제거

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -33,7 +33,6 @@ import {
   ZINDEX_MARKER_MOUSE_OVER,
   ZINDEX_MARKER_MOUSE_OUT,
 } from '@/utils/constants';
-import { getDustAverageGrade } from '@/utils/dustGrade';
 import ControlButton from './ControlButton';
 
 const Map = () => {
@@ -83,8 +82,7 @@ const Map = () => {
     ultraFineDustScale,
     ultraFineDustGrade,
   }: MarkerInfo) => {
-    const averageGrade = getDustAverageGrade(fineDustGrade, ultraFineDustGrade);
-    const backgroundColor = theme.colors[DUST_GRADE[averageGrade]];
+    const backgroundColor = theme.colors[DUST_GRADE[fineDustGrade]];
 
     return `
           <div class="dust-info-marker" id="${name}" data-finedustgrade="${fineDustGrade}" data-ultrafinedustgrade="${ultraFineDustGrade}" style="background-color: ${backgroundColor};">

--- a/src/components/common/Rank.tsx
+++ b/src/components/common/Rank.tsx
@@ -2,7 +2,6 @@ import { Flex, Text, Box } from '@chakra-ui/react';
 import { DustState } from '@/components/common';
 import type { DustFigures } from '@/types/dust';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
-import { getDustAverageGrade } from '@/utils/dustGrade';
 
 interface RankProps {
   type: 'sido' | 'city';
@@ -12,11 +11,6 @@ interface RankProps {
 }
 
 const Rank = ({ type, rank, title, dustFigures }: RankProps) => {
-  const dustAverageGrade = getDustAverageGrade(
-    dustFigures.fineDustGrade,
-    dustFigures.ultraFineDustGrade
-  );
-
   return (
     <Flex flex={1} alignItems="center">
       <Text
@@ -40,7 +34,7 @@ const Rank = ({ type, rank, title, dustFigures }: RankProps) => {
         {title}
       </Text>
       <Box width={type === 'sido' ? '26%' : '28%'} mr={8}>
-        <DustState dustGrade={dustAverageGrade} />
+        <DustState dustGrade={dustFigures.fineDustGrade} />
       </Box>
       <Flex direction="column" justifyContent="center" flexGrow={1}>
         <Flex justifyContent="space-between" alignItems="center" py={1}>

--- a/src/pages/DustForecast.tsx
+++ b/src/pages/DustForecast.tsx
@@ -18,7 +18,6 @@ import {
   INIT_SIDO,
   INIT_CITY,
 } from '@/utils/constants';
-import { getDustAverageGrade } from '@/utils/dustGrade';
 
 const animationKeyframes = keyframes`
   0% { background-position: 0 50%; }
@@ -48,18 +47,13 @@ const DustForecast = () => {
     (cityDustInfo) => cityDustInfo.cityName === searchedCity
   ) as CityDustInfo;
 
-  const dustAverageGrade = getDustAverageGrade(
-    dustInfo.fineDustGrade,
-    dustInfo.ultraFineDustGrade
-  );
-
   return (
     <Flex
       direction="column"
       minHeight="100vh"
       as={motion.div}
       animation={animation}
-      bgGradient={theme.backgroundColors[DUST_GRADE[dustAverageGrade]]}
+      bgGradient={theme.backgroundColors[DUST_GRADE[dustInfo.fineDustGrade]]}
       textAlign="center"
       backgroundSize="200% 200%"
     >

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -54,8 +54,6 @@ const Ranking = () => {
     setSelectedSido(nextSido);
   };
 
-  if (!sidoDustInfo) return <></>;
-
   return (
     <Flex
       direction="column"
@@ -63,7 +61,9 @@ const Ranking = () => {
       as={motion.div}
       animation={animation}
       bgGradient={
-        theme.backgroundColors[DUST_GRADE[sidoDustInfo.fineDustGrade]]
+        sidoDustInfo
+          ? theme.backgroundColors[DUST_GRADE[sidoDustInfo.fineDustGrade]]
+          : theme.backgroundColors[DUST_GRADE[0]]
       }
       textAlign="center"
       backgroundSize="200% 200%"
@@ -150,7 +150,11 @@ const Ranking = () => {
           py={3}
           borderRadius={25}
           color="#ffffff"
-          bg={theme.colors[DUST_GRADE[sidoDustInfo.fineDustGrade]] ?? 'gray'}
+          bg={
+            sidoDustInfo
+              ? theme.backgroundColors[DUST_GRADE[sidoDustInfo.fineDustGrade]]
+              : theme.backgroundColors[DUST_GRADE[0]]
+          }
           transition="all 500ms ease-in-out"
         >
           지역별 미세 먼지 농도 순위

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -1,7 +1,7 @@
 import { Flex, Box, Text, Center, keyframes, Skeleton } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
-import { ChangeEvent, useState, useEffect } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { getSidoDustInfo } from '@/apis/dustInfo';
 import { AsyncBoundary, DustFigureBar, DustState } from '@/components/common';
@@ -13,7 +13,6 @@ import {
   ULTRA_FINE_DUST,
   SIDO_GROUP,
 } from '@/utils/constants';
-import { getDustAverageGrade } from '@/utils/dustGrade';
 
 const animationKeyframes = keyframes`
   0% { background-position: 0 50%; }
@@ -30,7 +29,7 @@ const Ranking = () => {
   const place = serachParams.get('place') || '서울';
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
   const [selectedSido, setSelectedSido] = useState(place);
-  const [dustAverageGrade, setDustAverageGrade] = useState(0);
+
   const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
   const sidoNames = SIDO_GROUP.map((sido) => sido.sidoName);
 
@@ -55,15 +54,7 @@ const Ranking = () => {
     setSelectedSido(nextSido);
   };
 
-  useEffect(() => {
-    sidoDustInfo &&
-      setDustAverageGrade(
-        getDustAverageGrade(
-          sidoDustInfo.fineDustGrade,
-          sidoDustInfo.ultraFineDustGrade
-        )
-      );
-  }, [sidoDustInfo]);
+  if (!sidoDustInfo) return <></>;
 
   return (
     <Flex
@@ -71,7 +62,9 @@ const Ranking = () => {
       minHeight="100vh"
       as={motion.div}
       animation={animation}
-      bgGradient={theme.backgroundColors[DUST_GRADE[dustAverageGrade]]}
+      bgGradient={
+        theme.backgroundColors[DUST_GRADE[sidoDustInfo.fineDustGrade]]
+      }
       textAlign="center"
       backgroundSize="200% 200%"
     >
@@ -120,7 +113,9 @@ const Ranking = () => {
           현재의 대기질 지수는
         </Text>
         <Center my={5}>
-          <DustState dustGrade={sidoDustInfo ? dustAverageGrade : 0} />
+          <DustState
+            dustGrade={sidoDustInfo ? sidoDustInfo.fineDustGrade : 0}
+          />
         </Center>
         <DustFigureBar
           kindOfDust={FINE_DUST}
@@ -155,11 +150,7 @@ const Ranking = () => {
           py={3}
           borderRadius={25}
           color="#ffffff"
-          bg={
-            dustAverageGrade
-              ? theme.colors[DUST_GRADE[dustAverageGrade]]
-              : 'gray'
-          }
+          bg={theme.colors[DUST_GRADE[sidoDustInfo.fineDustGrade]] ?? 'gray'}
           transition="all 500ms ease-in-out"
         >
           지역별 미세 먼지 농도 순위

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -61,9 +61,7 @@ const Ranking = () => {
       as={motion.div}
       animation={animation}
       bgGradient={
-        sidoDustInfo
-          ? theme.backgroundColors[DUST_GRADE[sidoDustInfo.fineDustGrade]]
-          : theme.backgroundColors[DUST_GRADE[0]]
+        theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
       }
       textAlign="center"
       backgroundSize="200% 200%"
@@ -151,9 +149,7 @@ const Ranking = () => {
           borderRadius={25}
           color="#ffffff"
           bg={
-            sidoDustInfo
-              ? theme.backgroundColors[DUST_GRADE[sidoDustInfo.fineDustGrade]]
-              : theme.backgroundColors[DUST_GRADE[0]]
+            theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
           }
           transition="all 500ms ease-in-out"
         >

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -24,7 +24,7 @@ const theme = extendTheme({
     NORMAL:
       'linear-gradient(77deg, rgba(255,255,180,1) 0%, rgba(110,226,144,1) 50%, rgba(3,199,60,1) 100%)',
     GOOD: 'linear-gradient(77deg, rgba(255,255,180,1) 0%, rgba(83,202,242,1) 50%, rgba(48,162,255,1) 100%)',
-    NONE: 'gray',
+    NONE: 'rgba(154, 152, 160, 1)',
   },
 });
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -24,6 +24,7 @@ const theme = extendTheme({
     NORMAL:
       'linear-gradient(77deg, rgba(255,255,180,1) 0%, rgba(110,226,144,1) 50%, rgba(3,199,60,1) 100%)',
     GOOD: 'linear-gradient(77deg, rgba(255,255,180,1) 0%, rgba(83,202,242,1) 50%, rgba(48,162,255,1) 100%)',
+    NONE: 'gray',
   },
 });
 

--- a/src/utils/dustGrade.ts
+++ b/src/utils/dustGrade.ts
@@ -1,6 +1,0 @@
-export const getDustAverageGrade = (
-  fineDustGrade: number,
-  ultraFineDustGrade: number
-) => {
-  return Math.floor((fineDustGrade + ultraFineDustGrade) / 2);
-};


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #137 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 미세먼지 농도 기준을 (미세먼지 농도 grade + 초미세먼지농도 grade)/2 에서 미세먼지 농도 grade로 변경합니다.
## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://github.com/tooooo1/dust-rating/assets/12118892/7531e98c-5689-493d-bb70-d2ce107d47a1)

이제 미세먼지 오염도가 좀 더 적절하게 표현됩니다!
## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 필요없는 함수들을 제거하면서 불필요한 useEffect가 제거되었습니다. 😀
```
 useEffect(() => {
    sidoDustInfo &&
      setDustAverageGrade(
        getDustAverageGrade(
          sidoDustInfo.fineDustGrade,
          sidoDustInfo.ultraFineDustGrade
        )
      );
  }, [sidoDustInfo]);
  ```

- style theme의 backgroundColors에 None 상태의 색상이 추가되었습니다. none은 데이터가 없는 상태이므로 배경의 애니메이션이 필요하진 않을 것 같아서 간략하게 적용했습니다. 그러나 로딩중 색상이 기본(하늘색)으로 표기되는 현상이 있어 다음 pr 에서 확인해보겠습니다.

## 질문 <!-- 궁금한 부분을 적어주세요 -->
