### PR TITLE
refactor: CityRanking 페이지에 선택한 도시의 지역별 미세먼지 순위 랜더링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import Logo from '@/components/Logo';
 import {
   ChoicePage,
+  CityRankingPage,
   RankingPage,
   DustForecastPage,
   DustMapPage,
@@ -22,6 +23,7 @@ const router = createBrowserRouter(
     <Route path={ROUTE.HOME} element={<Logo />}>
       <Route index element={<ChoicePage />} />
       <Route path={ROUTE.RANKING} element={<RankingPage />} />
+      <Route path={ROUTE.CITY_RANKING} element={<CityRankingPage />} />
       <Route
         path={ROUTE.DUST_FORECAST}
         element={

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -4,7 +4,7 @@ import { Outlet } from 'react-router-dom';
 const Logo = () => (
   <Box position="relative" bg="#53caf2">
     <Image
-      src="images/il.jpg"
+      src="/images/il.jpg"
       alt="il"
       position="absolute"
       top={4}

--- a/src/components/Ranking/CityRankItem.tsx
+++ b/src/components/Ranking/CityRankItem.tsx
@@ -14,11 +14,7 @@ const CityRankItem = ({ rank, sido, city }: CityRankItemProps) => {
   const navigate = useNavigate();
 
   const handlePageNavigate = () => {
-    navigate(
-      `${ROUTE.DUST_FORECAST}?sido=${encodeURIComponent(
-        sido
-      )}&city=${encodeURIComponent(city.cityName)}`
-    );
+    navigate(`${ROUTE.DUST_FORECAST}?sido=${sido}&city=${city.cityName}`);
   };
 
   return (
@@ -31,7 +27,7 @@ const CityRankItem = ({ rank, sido, city }: CityRankItemProps) => {
       _hover={{ bg: '#dadada' }}
       onClick={handlePageNavigate}
     >
-      <Rank type="city" rank={rank} title={city.cityName} dustFigures={city} />
+      <Rank rank={rank} title={city.cityName} dustFigures={city} />
     </Flex>
   );
 };

--- a/src/components/Ranking/CityRankList.tsx
+++ b/src/components/Ranking/CityRankList.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getCityDustInfos } from '@/apis/dustInfo';
 import type { CityDustInfo, SortType } from '@/types/dust';
 import { FINE_DUST } from '@/utils/constants';
-import { sortDustList } from '@/utils/constants/sortDustList';
+import { sortDustList } from '@/utils/sortDustList';
 import CityRankItem from './CityRankItem';
 
 interface CityRankListProps {

--- a/src/components/Ranking/CityRankList.tsx
+++ b/src/components/Ranking/CityRankList.tsx
@@ -1,42 +1,43 @@
 import { Box } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { getCityDustInfos } from '@/apis/dustInfo';
-import type { CityDustInfo } from '@/types/dust';
+import type { CityDustInfo, SortType } from '@/types/dust';
+import { FINE_DUST } from '@/utils/constants';
+import { sortDustList } from '@/utils/constants/sortDustList';
 import CityRankItem from './CityRankItem';
 
 interface CityRankListProps {
   sido: string;
-  isShow: boolean;
+  isShow?: boolean;
+  sortType?: SortType;
 }
 
-const CityRankList = ({ sido, isShow }: CityRankListProps) => {
-  const { data: cityDustInfos } = useQuery<CityDustInfo[]>(
+const CityRankList = ({
+  sortType = FINE_DUST,
+  sido,
+  isShow = true,
+}: CityRankListProps) => {
+  const { data: cityDustInfos } = useQuery(
     ['city-dust-infos', sido],
     () => getCityDustInfos(sido),
     {
+      select: (data: CityDustInfo[]) =>
+        sortDustList<CityDustInfo>(sortType, data),
       refetchOnWindowFocus: false,
+      suspense: true,
     }
   );
 
   return (
-    <Box
-      flex="1"
-      bg="#e8e8e8"
-      borderRadius={10}
-      my={isShow ? 4 : 0}
-      px={{ base: 3, sm: 4 }}
-      cursor="pointer"
-    >
-      {isShow
-        ? cityDustInfos?.map((city, cityIndex) => (
-            <CityRankItem
-              key={city.cityName}
-              rank={cityIndex + 1}
-              sido={sido}
-              city={city}
-            />
-          ))
-        : null}
+    <Box flex="1" borderRadius={10} my={isShow ? 4 : 0} cursor="pointer">
+      {cityDustInfos?.map((city, cityIndex) => (
+        <CityRankItem
+          key={city.cityName}
+          rank={cityIndex + 1}
+          sido={sido}
+          city={city}
+        />
+      ))}
     </Box>
   );
 };

--- a/src/components/Ranking/SidoRankItem.tsx
+++ b/src/components/Ranking/SidoRankItem.tsx
@@ -31,7 +31,7 @@ const SidoRankItem = ({ rank, sido }: SidoRankItemProps) => {
       }}
       onClick={handleSidoClick}
     >
-      <Rank type="sido" rank={rank} title={sido.sidoName} dustFigures={sido} />
+      <Rank rank={rank} title={sido.sidoName} dustFigures={sido} />
       <CityRankList sido={sido.sidoName} isShow={isShow} />
     </Flex>
   );

--- a/src/components/Ranking/SidoRankList.tsx
+++ b/src/components/Ranking/SidoRankList.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { getSidoDustInfos } from '@/apis/dustInfo';
 import { SidoDustInfo, SortType } from '@/types/dust';
-import { sortDustList } from '@/utils/constants/sortDustList';
+import { sortDustList } from '@/utils/sortDustList';
 import SidoRankItem from './SidoRankItem';
 
 interface SidoRankListProps {

--- a/src/components/Ranking/SidoRankList.tsx
+++ b/src/components/Ranking/SidoRankList.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { getSidoDustInfos } from '@/apis/dustInfo';
-import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
+import { SidoDustInfo, SortType } from '@/types/dust';
+import { sortDustList } from '@/utils/constants/sortDustList';
 import SidoRankItem from './SidoRankItem';
 
 interface SidoRankListProps {
-  sortType: string;
+  sortType: SortType;
 }
 
 const SidoRankList = ({ sortType }: SidoRankListProps) => {
@@ -12,18 +13,7 @@ const SidoRankList = ({ sortType }: SidoRankListProps) => {
     ['sido-dust-infos', sortType],
     getSidoDustInfos,
     {
-      select: (data) => {
-        if (sortType === FINE_DUST) {
-          return data?.sort(
-            (prev, cur) => prev.fineDustScale - cur.fineDustScale
-          );
-        }
-        if (sortType === ULTRA_FINE_DUST) {
-          return data?.sort(
-            (prev, cur) => prev.ultraFineDustScale - cur.ultraFineDustScale
-          );
-        }
-      },
+      select: (data) => sortDustList<SidoDustInfo>(sortType, data),
       keepPreviousData: true,
       staleTime: 1000 * 60 * 5,
       suspense: true,

--- a/src/components/Ranking/SidoRankList.tsx
+++ b/src/components/Ranking/SidoRankList.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { getSidoDustInfos } from '@/apis/dustInfo';
-import { SidoDustInfo, SortType } from '@/types/dust';
+import type { SidoDustInfo, SortType } from '@/types/dust';
 import { sortDustList } from '@/utils/sortDustList';
 import SidoRankItem from './SidoRankItem';
 

--- a/src/components/common/ListFallback.tsx
+++ b/src/components/common/ListFallback.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from '@chakra-ui/react';
+
+interface ListFallbackProps {
+  count?: number;
+}
+
+const SIDO_COUNT = 17;
+
+const ListFallback = ({ count = SIDO_COUNT }: ListFallbackProps) => {
+  return (
+    <>
+      {[...Array(count).keys()].map((i) => (
+        <Skeleton
+          key={i}
+          width="100%"
+          height="3rem"
+          my={3}
+          endColor="#dfdfdf"
+        />
+      ))}
+    </>
+  );
+};
+
+export default ListFallback;

--- a/src/components/common/Rank.tsx
+++ b/src/components/common/Rank.tsx
@@ -4,13 +4,13 @@ import type { DustFigures } from '@/types/dust';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
 
 interface RankProps {
-  type: 'sido' | 'city';
+  size?: 'small' | 'large';
   rank: number;
   title: string;
   dustFigures: DustFigures;
 }
 
-const Rank = ({ type, rank, title, dustFigures }: RankProps) => {
+const Rank = ({ size = 'large', rank, title, dustFigures }: RankProps) => {
   return (
     <Flex flex={1} alignItems="center">
       <Text
@@ -25,15 +25,17 @@ const Rank = ({ type, rank, title, dustFigures }: RankProps) => {
       <Text
         as="p"
         width="30%"
-        fontSize={type === 'sido' ? { base: 20, sm: 24 } : { base: 18, sm: 20 }}
-        fontWeight={type === 'sido' ? 700 : 500}
+        fontSize={
+          size === 'small' ? { base: 18, sm: 20 } : { base: 20, sm: 24 }
+        }
+        fontWeight={size === 'small' ? 500 : 700}
         overflow="hidden"
         whiteSpace="nowrap"
         textOverflow="ellipsis"
       >
         {title}
       </Text>
-      <Box width={type === 'sido' ? '26%' : '28%'} mr={8}>
+      <Box width={size === 'small' ? '26%' : '28%'} mr={8}>
         <DustState dustGrade={dustFigures.fineDustGrade} />
       </Box>
       <Flex direction="column" justifyContent="center" flexGrow={1}>
@@ -42,7 +44,7 @@ const Rank = ({ type, rank, title, dustFigures }: RankProps) => {
             as="p"
             mr={2}
             fontSize={
-              type === 'sido' ? { base: 14, sm: 16 } : { base: 12, sm: 14 }
+              size === 'small' ? { base: 12, sm: 14 } : { base: 14, sm: 16 }
             }
             fontWeight={500}
             overflow="hidden"
@@ -54,7 +56,7 @@ const Rank = ({ type, rank, title, dustFigures }: RankProps) => {
           <Text
             as="p"
             fontSize={
-              type === 'sido' ? { base: 14, sm: 16 } : { base: 12, sm: 14 }
+              size === 'small' ? { base: 12, sm: 14 } : { base: 14, sm: 16 }
             }
             fontWeight={800}
           >
@@ -66,7 +68,7 @@ const Rank = ({ type, rank, title, dustFigures }: RankProps) => {
             as="p"
             mr={2}
             fontSize={
-              type === 'sido' ? { base: 14, sm: 16 } : { base: 12, sm: 14 }
+              size === 'small' ? { base: 12, sm: 14 } : { base: 14, sm: 16 }
             }
             fontWeight={500}
             overflow="hidden"
@@ -78,7 +80,7 @@ const Rank = ({ type, rank, title, dustFigures }: RankProps) => {
           <Text
             as="p"
             fontSize={
-              type === 'sido' ? { base: 14, sm: 16 } : { base: 12, sm: 14 }
+              size === 'small' ? { base: 12, sm: 14 } : { base: 14, sm: 16 }
             }
             fontWeight={800}
           >

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -4,3 +4,4 @@ export { default as DustLevel } from '@/components/common/DustLevel';
 export { default as DustState } from '@/components/common/DustState';
 export { default as ErrorFallback } from '@/components/common/ErrorFallback';
 export { default as Rank } from '@/components/common/Rank';
+export { default as ListFallback } from '@/components/common/ListFallback';

--- a/src/pages/Choice.tsx
+++ b/src/pages/Choice.tsx
@@ -9,7 +9,7 @@ const Choice = () => {
   const [place, setPlace] = useState(INIT_SIDO);
 
   const handleResultPageNavigate = () => {
-    navigate(`${ROUTE.RANKING}?place=${encodeURIComponent(place)}`);
+    navigate(`${ROUTE.RANKING}/${place}`);
   };
 
   const handleMapPageNavigate = () => {

--- a/src/pages/CityRanking.tsx
+++ b/src/pages/CityRanking.tsx
@@ -1,4 +1,4 @@
-import { Flex, Box, Text, Center, keyframes } from '@chakra-ui/react';
+import { Flex, Box, Text, Center } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { ChangeEvent, useState } from 'react';
@@ -20,15 +20,8 @@ import {
   SIDO_GROUP,
   INIT_SIDO,
   ROUTE,
+  BACKGROUND_ANIMATION,
 } from '@/utils/constants';
-
-const animationKeyframes = keyframes`
-  0% { background-position: 0 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
-`;
-
-const animation = `${animationKeyframes} 6s ease infinite`;
 
 const CityRanking = () => {
   const navigate = useNavigate();
@@ -65,7 +58,7 @@ const CityRanking = () => {
       direction="column"
       minHeight="100vh"
       as={motion.div}
-      animation={animation}
+      animation={BACKGROUND_ANIMATION}
       bgGradient={
         theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
       }

--- a/src/pages/CityRanking.tsx
+++ b/src/pages/CityRanking.tsx
@@ -1,0 +1,180 @@
+import { Flex, Box, Text, Center, keyframes } from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import { ChangeEvent, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { getSidoDustInfo } from '@/apis/dustInfo';
+import {
+  AsyncBoundary,
+  DustFigureBar,
+  DustState,
+  ListFallback,
+} from '@/components/common';
+import { SelectList, CityRankList } from '@/components/Ranking';
+import theme from '@/styles/theme';
+import type { SortType } from '@/types/dust';
+import {
+  DUST_GRADE,
+  FINE_DUST,
+  ULTRA_FINE_DUST,
+  SIDO_GROUP,
+  INIT_SIDO,
+  ROUTE,
+} from '@/utils/constants';
+
+const animationKeyframes = keyframes`
+  0% { background-position: 0 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+`;
+
+const animation = `${animationKeyframes} 6s ease infinite`;
+
+const CityRanking = () => {
+  const navigate = useNavigate();
+
+  const { place = INIT_SIDO } = useParams();
+  const [selectedSortType, setSelectedSortType] = useState<SortType>(FINE_DUST);
+  const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
+  const sidoNames = SIDO_GROUP.map((sido) => sido.sidoName);
+
+  const { data: sidoDustInfo } = useQuery(
+    ['sido-dust-info', place],
+    () => getSidoDustInfo(place),
+    {
+      staleTime: 1000 * 60 * 5,
+    }
+  );
+
+  const handleSortKeyChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { target } = e;
+
+    target.value === FINE_DUST
+      ? setSelectedSortType(FINE_DUST)
+      : setSelectedSortType(ULTRA_FINE_DUST);
+  };
+
+  const handleSelectedSidoChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    navigate(`${ROUTE.RANKING}/${e.target.value}`);
+
+    setSelectedSortType(FINE_DUST);
+  };
+
+  return (
+    <Flex
+      direction="column"
+      minHeight="100vh"
+      as={motion.div}
+      animation={animation}
+      bgGradient={
+        theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
+      }
+      textAlign="center"
+      backgroundSize="200% 200%"
+    >
+      <Text
+        as="h1"
+        fontSize={{ base: 18, sm: 20, md: 24 }}
+        fontWeight={600}
+        color="#ffffff"
+        mt={20}
+        mb={{ base: 2, sm: 3, md: 4 }}
+      >
+        전국 미세 먼지 농도는 다음과 같습니다
+      </Text>
+      <Text
+        as="p"
+        fontSize={{ base: 14, sm: 18, md: 20 }}
+        fontWeight={300}
+        color="#ffffff"
+        mb={6}
+      >
+        {sidoDustInfo ? sidoDustInfo.dataTime : '0000-00-00 00:00'} 기준
+      </Text>
+      <Box
+        maxWidth="37.5rem"
+        width={{ base: '80%', sm: '80%' }}
+        margin="0 auto"
+        borderTopRadius={10}
+        textAlign="center"
+        bg="rgba(255, 255, 255, 0.6)"
+        boxShadow="0 4px 30px rgba(0, 0, 0, 0.1)"
+        backdropFilter="blur(7px)"
+        px={{ base: 4, sm: 6 }}
+        py={{ base: 6, sm: 8 }}
+      >
+        <SelectList
+          handleChange={handleSelectedSidoChange}
+          selectOptions={sidoNames}
+          defaultValue={place}
+        />
+        <Text
+          as="div"
+          mt="1rem"
+          fontSize={{ base: 16, sm: 18 }}
+          color="#4d4d4d"
+        >
+          현재의 대기질 지수는
+        </Text>
+        <Center my={5}>
+          <DustState
+            dustGrade={sidoDustInfo ? sidoDustInfo.fineDustGrade : 0}
+          />
+        </Center>
+        <DustFigureBar
+          kindOfDust={FINE_DUST}
+          scale={sidoDustInfo?.fineDustScale}
+          grade={sidoDustInfo?.fineDustGrade}
+        />
+        <DustFigureBar
+          kindOfDust={ULTRA_FINE_DUST}
+          scale={sidoDustInfo?.ultraFineDustScale}
+          grade={sidoDustInfo?.ultraFineDustGrade}
+        />
+      </Box>
+      <Flex
+        direction="column"
+        justifyContent="center"
+        alignItems="center"
+        maxWidth="47.5rem"
+        width={{ base: '100%', sm: '100%' }}
+        margin="0 auto"
+        borderRadius={20}
+        bg="#f6f6f6"
+        mb={20}
+        px={{ base: 6, sm: 14, md: 20 }}
+        py={10}
+      >
+        <Text
+          as="p"
+          fontSize={{ base: 16, sm: 18 }}
+          fontWeight={400}
+          margin="0 auto"
+          px={8}
+          py={3}
+          borderRadius={25}
+          color="#ffffff"
+          bg={
+            theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
+          }
+          transition="all 500ms ease-in-out"
+        >
+          지역별 미세 먼지 농도 순위
+        </Text>
+        <SelectList
+          handleChange={handleSortKeyChange}
+          selectOptions={kindOfDust}
+          defaultValue={selectedSortType}
+        />
+        <AsyncBoundary
+          title="지역별 미세먼지 정보를 불러오지 못했어요."
+          suspenseFallback={<ListFallback />}
+        >
+          <CityRankList sido={place} sortType={selectedSortType} />
+        </AsyncBoundary>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default CityRanking;

--- a/src/pages/CityRanking.tsx
+++ b/src/pages/CityRanking.tsx
@@ -40,17 +40,15 @@ const CityRanking = () => {
   );
 
   const handleSortKeyChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const { target } = e;
-
-    target.value === FINE_DUST
+    e.target.value === FINE_DUST
       ? setSelectedSortType(FINE_DUST)
       : setSelectedSortType(ULTRA_FINE_DUST);
   };
 
   const handleSelectedSidoChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    navigate(`${ROUTE.RANKING}/${e.target.value}`);
-
     setSelectedSortType(FINE_DUST);
+
+    navigate(`${ROUTE.RANKING}/${e.target.value}`);
   };
 
   return (
@@ -60,7 +58,7 @@ const CityRanking = () => {
       as={motion.div}
       animation={BACKGROUND_ANIMATION}
       bgGradient={
-        theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
+        theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade || 0]]
       }
       textAlign="center"
       backgroundSize="200% 200%"
@@ -82,7 +80,7 @@ const CityRanking = () => {
         color="#ffffff"
         mb={6}
       >
-        {sidoDustInfo ? sidoDustInfo.dataTime : '0000-00-00 00:00'} 기준
+        {sidoDustInfo?.dataTime || '0000-00-00 00:00'} 기준
       </Text>
       <Box
         maxWidth="37.5rem"
@@ -110,9 +108,7 @@ const CityRanking = () => {
           현재의 대기질 지수는
         </Text>
         <Center my={5}>
-          <DustState
-            dustGrade={sidoDustInfo ? sidoDustInfo.fineDustGrade : 0}
-          />
+          <DustState dustGrade={sidoDustInfo?.fineDustGrade || 0} />
         </Center>
         <DustFigureBar
           kindOfDust={FINE_DUST}
@@ -148,7 +144,7 @@ const CityRanking = () => {
           borderRadius={25}
           color="#ffffff"
           bg={
-            theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
+            theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade || 0]]
           }
           transition="all 500ms ease-in-out"
         >

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -10,7 +10,7 @@ import {
   DustState,
   ListFallback,
 } from '@/components/common';
-import { SelectList, CityRankList } from '@/components/Ranking';
+import { SelectList, SidoRankList } from '@/components/Ranking';
 import theme from '@/styles/theme';
 import {
   DUST_GRADE,
@@ -170,7 +170,7 @@ const Ranking = () => {
           title="지역별 미세먼지 정보를 불러오지 못했어요."
           suspenseFallback={<ListFallback />}
         >
-          <CityRankList sido={selectedSido} />
+          <SidoRankList sortType={selectedSortKey} />
         </AsyncBoundary>
       </Flex>
     </Flex>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -1,17 +1,23 @@
-import { Flex, Box, Text, Center, keyframes, Skeleton } from '@chakra-ui/react';
+import { Flex, Box, Text, Center, keyframes } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { ChangeEvent, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { getSidoDustInfo } from '@/apis/dustInfo';
-import { AsyncBoundary, DustFigureBar, DustState } from '@/components/common';
-import { SelectList, SidoRankList } from '@/components/Ranking';
+import {
+  AsyncBoundary,
+  DustFigureBar,
+  DustState,
+  ListFallback,
+} from '@/components/common';
+import { SelectList, CityRankList } from '@/components/Ranking';
 import theme from '@/styles/theme';
 import {
   DUST_GRADE,
   FINE_DUST,
   ULTRA_FINE_DUST,
   SIDO_GROUP,
+  INIT_SIDO,
 } from '@/utils/constants';
 
 const animationKeyframes = keyframes`
@@ -26,7 +32,7 @@ type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 
 const Ranking = () => {
   const [serachParams, setSearchParams] = useSearchParams();
-  const place = serachParams.get('place') || '서울';
+  const place = serachParams.get('place') || INIT_SIDO;
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
   const [selectedSido, setSelectedSido] = useState(place);
 
@@ -162,17 +168,9 @@ const Ranking = () => {
         />
         <AsyncBoundary
           title="지역별 미세먼지 정보를 불러오지 못했어요."
-          suspenseFallback={[...Array(17).keys()].map((i) => (
-            <Skeleton
-              key={i}
-              width="100%"
-              height="3rem"
-              my="1.55rem"
-              endColor="#dfdfdf"
-            />
-          ))}
+          suspenseFallback={<ListFallback />}
         >
-          <SidoRankList sortType={selectedSortKey} />
+          <CityRankList sido={selectedSido} />
         </AsyncBoundary>
       </Flex>
     </Flex>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -1,4 +1,4 @@
-import { Flex, Box, Text, Center, keyframes } from '@chakra-ui/react';
+import { Flex, Box, Text, Center } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { ChangeEvent, useState } from 'react';
@@ -18,15 +18,8 @@ import {
   ULTRA_FINE_DUST,
   SIDO_GROUP,
   INIT_SIDO,
+  BACKGROUND_ANIMATION,
 } from '@/utils/constants';
-
-const animationKeyframes = keyframes`
-  0% { background-position: 0 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
-`;
-
-const animation = `${animationKeyframes} 6s ease infinite`;
 
 type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 
@@ -65,7 +58,7 @@ const Ranking = () => {
       direction="column"
       minHeight="100vh"
       as={motion.div}
-      animation={animation}
+      animation={BACKGROUND_ANIMATION}
       bgGradient={
         theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
       }

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -41,8 +41,7 @@ const Ranking = () => {
   );
 
   const handleSortKeyChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const { target } = e;
-    target.value === FINE_DUST
+    e.target.value === FINE_DUST
       ? setSelectedSortKey(FINE_DUST)
       : setSelectedSortKey(ULTRA_FINE_DUST);
   };
@@ -60,7 +59,7 @@ const Ranking = () => {
       as={motion.div}
       animation={BACKGROUND_ANIMATION}
       bgGradient={
-        theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
+        theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade || 0]]
       }
       textAlign="center"
       backgroundSize="200% 200%"
@@ -82,7 +81,7 @@ const Ranking = () => {
         color="#ffffff"
         mb={6}
       >
-        {sidoDustInfo ? sidoDustInfo.dataTime : '0000-00-00 00:00'} 기준
+        {sidoDustInfo?.dataTime || '0000-00-00 00:00'} 기준
       </Text>
       <Box
         maxWidth="37.5rem"
@@ -110,9 +109,7 @@ const Ranking = () => {
           현재의 대기질 지수는
         </Text>
         <Center my={5}>
-          <DustState
-            dustGrade={sidoDustInfo ? sidoDustInfo.fineDustGrade : 0}
-          />
+          <DustState dustGrade={sidoDustInfo?.fineDustGrade || 0} />
         </Center>
         <DustFigureBar
           kindOfDust={FINE_DUST}
@@ -148,7 +145,7 @@ const Ranking = () => {
           borderRadius={25}
           color="#ffffff"
           bg={
-            theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
+            theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade || 0]]
           }
           transition="all 500ms ease-in-out"
         >

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,4 +1,5 @@
 export { default as ChoicePage } from '@/pages/Choice';
-export { default as RankingPage } from '@/pages/Ranking';
+export { default as CityRankingPage } from '@/pages/CityRanking';
 export { default as DustForecastPage } from '@/pages/DustForecast';
 export { default as DustMapPage } from '@/pages/DustMap';
+export { default as RankingPage } from '@/pages/Ranking';

--- a/src/types/dust.ts
+++ b/src/types/dust.ts
@@ -1,4 +1,8 @@
+import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
+
 type Flag = null | '통신장애';
+
+export type SortType = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 
 export type GradeType = 'NONE' | 'GOOD' | 'NORMAL' | 'BAD' | 'DANGER';
 

--- a/src/utils/constants/animations.ts
+++ b/src/utils/constants/animations.ts
@@ -1,0 +1,9 @@
+import { keyframes } from '@chakra-ui/react';
+
+const backgroundAnimationKeyframes = keyframes`
+  0% { background-position: 0 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+`;
+
+export const BACKGROUND_ANIMATION = `${backgroundAnimationKeyframes} 6s ease infinite`;

--- a/src/utils/constants/dust.ts
+++ b/src/utils/constants/dust.ts
@@ -1,4 +1,4 @@
-import { GradeType } from '@/types/dust';
+import type { GradeType } from '@/types/dust';
 
 export const FINE_DUST = '미세먼지';
 export const ULTRA_FINE_DUST = '초미세먼지';

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -11,3 +11,4 @@ export {
   ZINDEX_MARKER_MOUSE_OVER,
   ZINDEX_MARKER_MOUSE_OUT,
 } from '@/utils/constants/map';
+export { BACKGROUND_ANIMATION } from '@/utils/constants/animations';

--- a/src/utils/constants/route.ts
+++ b/src/utils/constants/route.ts
@@ -1,6 +1,7 @@
 export const ROUTE = {
   HOME: '/',
   RANKING: '/ranking',
+  CITY_RANKING: '/ranking/:place',
   DUST_FORECAST: '/dust-forecast',
   DUST_MAP: '/dust-map',
 };

--- a/src/utils/constants/sortDustList.ts
+++ b/src/utils/constants/sortDustList.ts
@@ -1,0 +1,16 @@
+import { CityDustInfo, SidoDustInfo, SortType } from '@/types/dust';
+import { FINE_DUST, ULTRA_FINE_DUST } from './dust';
+
+export const sortDustList = <T extends SidoDustInfo | CityDustInfo>(
+  sortType: SortType,
+  data: T[]
+) => {
+  if (sortType === FINE_DUST) {
+    return data?.sort((prev, cur) => prev.fineDustScale - cur.fineDustScale);
+  }
+  if (sortType === ULTRA_FINE_DUST) {
+    return data?.sort(
+      (prev, cur) => prev.ultraFineDustScale - cur.ultraFineDustScale
+    );
+  }
+};

--- a/src/utils/sortDustList.ts
+++ b/src/utils/sortDustList.ts
@@ -1,16 +1,12 @@
-import { CityDustInfo, SidoDustInfo, SortType } from '@/types/dust';
-import { FINE_DUST, ULTRA_FINE_DUST } from './constants/dust';
+import type { CityDustInfo, SidoDustInfo, SortType } from '@/types/dust';
+import { FINE_DUST } from './constants/dust';
 
 export const sortDustList = <T extends SidoDustInfo | CityDustInfo>(
   sortType: SortType,
   data: T[]
 ) => {
-  if (sortType === FINE_DUST) {
-    return data?.sort((prev, cur) => prev.fineDustScale - cur.fineDustScale);
-  }
-  if (sortType === ULTRA_FINE_DUST) {
-    return data?.sort(
-      (prev, cur) => prev.ultraFineDustScale - cur.ultraFineDustScale
-    );
-  }
+  const scaleKey =
+    sortType === FINE_DUST ? 'fineDustScale' : 'ultraFineDustScale';
+
+  return data.sort((a, b) => a[scaleKey] - b[scaleKey]);
 };

--- a/src/utils/sortDustList.ts
+++ b/src/utils/sortDustList.ts
@@ -1,5 +1,5 @@
 import { CityDustInfo, SidoDustInfo, SortType } from '@/types/dust';
-import { FINE_DUST, ULTRA_FINE_DUST } from './dust';
+import { FINE_DUST, ULTRA_FINE_DUST } from './constants/dust';
 
 export const sortDustList = <T extends SidoDustInfo | CityDustInfo>(
   sortType: SortType,

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,4 +1,4 @@
-import { DustValidity } from '@/types/dust';
+import type { DustValidity } from '@/types/dust';
 
 export const dustScaleValidate = (scale: DustValidity) => {
   if (


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #134 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- CityRanking 페이지에 선택한 도시의 지역별 미세먼지 순위 랜더링

## 🎨 구현 스크린샷 
https://github.com/tooooo1/dust-rating/assets/76807107/f92dec3d-fed8-4da5-981c-8dc0626ecef5

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- CityRanking 페이지 추가 -> Ranking 페이지는 따로 건드리지 않았어요.
- 미세먼지, 초미세먼지 별 정렬하는 함수 sortDustList 생성
- ListFallback 컴포넌트 구현
- Ranking 컴포넌트는 '/ranking', CityRanking 컴포넌트는 '/ranking/:place'로 설정했어요.

## 질문 <!-- 궁금한 부분을 적어주세요 -->
