### PR TITLE
fix: 시/도 변경 시 화면 배경이 깜빡 거리던 현상 수정

### DIFF
--- a/src/pages/Choice.tsx
+++ b/src/pages/Choice.tsx
@@ -28,6 +28,7 @@ const Choice = () => {
       alignItems="center"
       color="#ffffff"
       textAlign="center"
+      backgroundColor="#53caf2"
     >
       <Image src="images/location.png" alt="location" width={30} height={30} />
       <Text as="span" fontSize={18} fontWeight={400} mt={4}>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -65,7 +65,7 @@ const Ranking = () => {
       animation={animation}
       bgGradient={
         sidoDustInfo
-          ? theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade]]
+          ? theme.backgroundColors[DUST_GRADE[sidoDustInfo.fineDustGrade]]
           : bgcolor
       }
       textAlign="center"

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -29,7 +29,7 @@ const Ranking = () => {
   const place = serachParams.get('place') || '서울';
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
   const [selectedSido, setSelectedSido] = useState(place);
-
+  const [bgcolor, setBgcolor] = useState('white');
   const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
   const sidoNames = SIDO_GROUP.map((sido) => sido.sidoName);
 
@@ -50,8 +50,11 @@ const Ranking = () => {
 
   const handleSelectedSidoChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const nextSido = e.target.value;
-    setSearchParams({ place: nextSido }, { replace: true });
     setSelectedSido(nextSido);
+    setSearchParams({ place: nextSido }, { replace: true });
+    setBgcolor(
+      theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
+    );
   };
 
   return (
@@ -61,10 +64,11 @@ const Ranking = () => {
       as={motion.div}
       animation={animation}
       bgGradient={
-        theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
+        sidoDustInfo
+          ? theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade]]
+          : bgcolor
       }
       textAlign="center"
-      backgroundSize="200% 200%"
     >
       <Text
         as="h1"

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -25,8 +25,8 @@ const animation = `${animationKeyframes} 6s ease infinite`;
 type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 
 const Ranking = () => {
-  const [serachParams, setSearchParams] = useSearchParams();
-  const place = serachParams.get('place') || '서울';
+  const [searchParams, setSearchParams] = useSearchParams();
+  const place = searchParams.get('place') || '서울';
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
   const [selectedSido, setSelectedSido] = useState(place);
   const [bgcolor, setBgcolor] = useState(theme.backgroundColors[DUST_GRADE[0]]);

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -29,7 +29,7 @@ const Ranking = () => {
   const place = serachParams.get('place') || '서울';
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
   const [selectedSido, setSelectedSido] = useState(place);
-  const [bgcolor, setBgcolor] = useState('white');
+  const [bgcolor, setBgcolor] = useState(theme.backgroundColors[DUST_GRADE[0]]);
   const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
   const sidoNames = SIDO_GROUP.map((sido) => sido.sidoName);
 

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -30,7 +30,7 @@ const Ranking = () => {
   const place = searchParams.get('place') || INIT_SIDO;
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
   const [selectedSido, setSelectedSido] = useState(place);
-  const [bgcolor, setBgcolor] = useState(theme.backgroundColors[DUST_GRADE[0]]);
+  const [bgcolorGrade, setBgcolorGrade] = useState(0);
   const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
   const sidoNames = SIDO_GROUP.map((sido) => sido.sidoName);
 
@@ -53,8 +53,8 @@ const Ranking = () => {
     const nextSido = e.target.value;
     setSelectedSido(nextSido);
     setSearchParams({ place: nextSido }, { replace: true });
-    setBgcolor(
-      theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
+    setBgcolorGrade(
+      (prevBgcolor) => sidoDustInfo?.fineDustGrade ?? prevBgcolor
     );
   };
 
@@ -65,9 +65,9 @@ const Ranking = () => {
       as={motion.div}
       animation={animation}
       bgGradient={
-        sidoDustInfo
-          ? theme.backgroundColors[DUST_GRADE[sidoDustInfo.fineDustGrade]]
-          : bgcolor
+        theme.backgroundColors[
+          DUST_GRADE[sidoDustInfo?.fineDustGrade ?? bgcolorGrade]
+        ]
       }
       textAlign="center"
     >
@@ -154,7 +154,9 @@ const Ranking = () => {
           borderRadius={25}
           color="#ffffff"
           bg={
-            theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]
+            theme.backgroundColors[
+              DUST_GRADE[sidoDustInfo?.fineDustGrade ?? bgcolorGrade]
+            ]
           }
           transition="all 500ms ease-in-out"
         >

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -12,6 +12,7 @@ import {
   FINE_DUST,
   ULTRA_FINE_DUST,
   SIDO_GROUP,
+  INIT_SIDO,
 } from '@/utils/constants';
 
 const animationKeyframes = keyframes`
@@ -26,7 +27,7 @@ type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 
 const Ranking = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const place = searchParams.get('place') || '서울';
+  const place = searchParams.get('place') || INIT_SIDO;
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
   const [selectedSido, setSelectedSido] = useState(place);
   const [bgcolor, setBgcolor] = useState(theme.backgroundColors[DUST_GRADE[0]]);

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -24,7 +24,7 @@ const theme = extendTheme({
     NORMAL:
       'linear-gradient(77deg, rgba(255,255,180,1) 0%, rgba(110,226,144,1) 50%, rgba(3,199,60,1) 100%)',
     GOOD: 'linear-gradient(77deg, rgba(255,255,180,1) 0%, rgba(83,202,242,1) 50%, rgba(48,162,255,1) 100%)',
-    NONE: 'rgba(154, 152, 160, 1)',
+    NONE: '#ffffff8f',
   },
 });
 


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #139 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 랭킹 페이지에서 시/도 변경 시 화면의 배경이 기본색으로 돌아갔다가 변하는 현상을 수정합니다.

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
[chrome-capture-2023-4-20.webm](https://github.com/tooooo1/dust-rating/assets/12118892/62c5f6cd-8be4-40b4-9d1c-5275fe130e39)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 정확한 원인을 파악하지 못하여 임시 방편으로 useState를 사용하여 개선하였습니다. 문제점이 무엇인지 파악되면 재수정 하도록 하겠습니다.
- useState를 사용하여서 새로 선택한 시/도 정보를 활용하여 새로운 배경색을 계산하기 전까지 활용하도록 하였습니다.

## 질문 <!-- 궁금한 부분을 적어주세요 -->
- 정확히 왜? 이런 문제가 발생하는지 파악하지 못했습니다. 재랜더링이 일어나서 sidoDustInfo가 아직 없는 상황이라면 기본 값으로 설정한 ```theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade ?? 0]]```에 해당하는 색상이 나올거라고 생각했는데 Logo 컴포넌트의 Box 엘리먼트의 bg색상이 나오더라구요.  아래 쪽에 존재하는 '지역별 미세 먼지 농도 순위' 에는 정상적으로 적용되것으로 보였습니다. 