### PR TITLE
fix: 모달의 정보가 올바르게 표기되도록 수정

### DIFF
--- a/src/components/Map/MarkerModalDustInfo.tsx
+++ b/src/components/Map/MarkerModalDustInfo.tsx
@@ -5,20 +5,18 @@ import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
 
 interface MarkerModalDustInfoProps {
   kindOfDust: typeof FINE_DUST | typeof ULTRA_FINE_DUST;
-  dustGradeAVG: number;
   dustScale: number;
   dustGrade: number;
 }
 
 export const MarkerModalDustInfo = ({
   kindOfDust,
-  dustGradeAVG,
   dustScale,
   dustGrade,
 }: MarkerModalDustInfoProps) => {
   return (
     <Flex flexDirection="column">
-      <DustState dustGrade={dustGradeAVG} />
+      <DustState dustGrade={dustGrade} />
       <DustFigureBar
         kindOfDust={kindOfDust}
         scale={dustScale}

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -51,9 +51,6 @@ const Map = () => {
     ultraFineDustScale: 0,
     ultraFineDustGrade: 0,
   });
-  const dustAverageGrade = Math.floor(
-    (dustInfo.fineDustGrade + dustInfo.ultraFineDustGrade) / 2
-  );
   const { isOpen, onOpen, onClose } = useDisclosure();
   const {
     map,
@@ -306,13 +303,11 @@ const Map = () => {
           <ModalBody>
             <MarkerModalDustInfo
               kindOfDust={FINE_DUST}
-              dustGradeAVG={dustAverageGrade}
               dustScale={dustInfo.fineDustScale}
               dustGrade={dustInfo.fineDustGrade}
             />
             <MarkerModalDustInfo
               kindOfDust={ULTRA_FINE_DUST}
-              dustGradeAVG={dustAverageGrade}
               dustScale={dustInfo.ultraFineDustScale}
               dustGrade={dustInfo.ultraFineDustGrade}
             />


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #143 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 마커의 모달에 표기되는 정보가 올바르게 표현되도록 수정했습니다.( grade 평균값 -> finedustGrade)

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
[chrome-capture-2023-4-20.webm](https://github.com/tooooo1/dust-rating/assets/12118892/f99b722c-dffb-46b5-9d00-77a221b94bf8)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 미세 먼지 표기 방법을 바꾸는 과정에서 마커의 모달 부분이 누락되어 부분을 수정했습니다.
## 질문 <!-- 궁금한 부분을 적어주세요 -->
