### PR TITLE
fix: cityRank 페이지 깜빡거림 현상 수정

### DIFF
--- a/src/pages/CityRanking.tsx
+++ b/src/pages/CityRanking.tsx
@@ -17,10 +17,11 @@ import {
   DUST_GRADE,
   FINE_DUST,
   ULTRA_FINE_DUST,
-  SIDO_GROUP,
   INIT_SIDO,
   ROUTE,
   BACKGROUND_ANIMATION,
+  SIDO_NAMES,
+  KIND_OF_DUST,
 } from '@/utils/constants';
 
 const CityRanking = () => {
@@ -28,8 +29,7 @@ const CityRanking = () => {
 
   const { place = INIT_SIDO } = useParams();
   const [selectedSortType, setSelectedSortType] = useState<SortType>(FINE_DUST);
-  const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
-  const sidoNames = SIDO_GROUP.map((sido) => sido.sidoName);
+  const [bgcolorGrade, setBgcolorGrade] = useState(0);
 
   const { data: sidoDustInfo } = useQuery(
     ['sido-dust-info', place],
@@ -47,7 +47,9 @@ const CityRanking = () => {
 
   const handleSelectedSidoChange = (e: ChangeEvent<HTMLSelectElement>) => {
     setSelectedSortType(FINE_DUST);
-
+    setBgcolorGrade(
+      (prevBgcolor) => sidoDustInfo?.fineDustGrade ?? prevBgcolor
+    );
     navigate(`${ROUTE.RANKING}/${e.target.value}`);
   };
 
@@ -58,7 +60,9 @@ const CityRanking = () => {
       as={motion.div}
       animation={BACKGROUND_ANIMATION}
       bgGradient={
-        theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade || 0]]
+        theme.backgroundColors[
+          DUST_GRADE[sidoDustInfo?.fineDustGrade ?? bgcolorGrade]
+        ]
       }
       textAlign="center"
       backgroundSize="200% 200%"
@@ -96,7 +100,7 @@ const CityRanking = () => {
       >
         <SelectList
           handleChange={handleSelectedSidoChange}
-          selectOptions={sidoNames}
+          selectOptions={SIDO_NAMES}
           defaultValue={place}
         />
         <Text
@@ -144,7 +148,9 @@ const CityRanking = () => {
           borderRadius={25}
           color="#ffffff"
           bg={
-            theme.backgroundColors[DUST_GRADE[sidoDustInfo?.fineDustGrade || 0]]
+            theme.backgroundColors[
+              DUST_GRADE[sidoDustInfo?.fineDustGrade ?? bgcolorGrade]
+            ]
           }
           transition="all 500ms ease-in-out"
         >
@@ -152,7 +158,7 @@ const CityRanking = () => {
         </Text>
         <SelectList
           handleChange={handleSortKeyChange}
-          selectOptions={kindOfDust}
+          selectOptions={KIND_OF_DUST}
           defaultValue={selectedSortType}
         />
         <AsyncBoundary

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -16,9 +16,10 @@ import {
   DUST_GRADE,
   FINE_DUST,
   ULTRA_FINE_DUST,
-  SIDO_GROUP,
   INIT_SIDO,
   BACKGROUND_ANIMATION,
+  KIND_OF_DUST,
+  SIDO_NAMES,
 } from '@/utils/constants';
 
 type SortKey = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
@@ -29,8 +30,6 @@ const Ranking = () => {
   const [selectedSortKey, setSelectedSortKey] = useState<SortKey>(FINE_DUST);
   const [selectedSido, setSelectedSido] = useState(place);
   const [bgcolorGrade, setBgcolorGrade] = useState(0);
-  const kindOfDust = [FINE_DUST, ULTRA_FINE_DUST];
-  const sidoNames = SIDO_GROUP.map((sido) => sido.sidoName);
 
   const { data: sidoDustInfo } = useQuery(
     ['sido-dust-info', selectedSido],
@@ -101,7 +100,7 @@ const Ranking = () => {
       >
         <SelectList
           handleChange={handleSelectedSidoChange}
-          selectOptions={sidoNames}
+          selectOptions={SIDO_NAMES}
           defaultValue={selectedSido}
         />
         <Text
@@ -159,7 +158,7 @@ const Ranking = () => {
         </Text>
         <SelectList
           handleChange={handleSortKeyChange}
-          selectOptions={kindOfDust}
+          selectOptions={KIND_OF_DUST}
           defaultValue={selectedSortKey}
         />
         <AsyncBoundary

--- a/src/utils/constants/city.ts
+++ b/src/utils/constants/city.ts
@@ -18,5 +18,7 @@ export const SIDO_GROUP = [
   { sidoName: '세종', cityNumber: 16 },
 ];
 
+export const SIDO_NAMES = SIDO_GROUP.map((sido) => sido.sidoName);
+
 export const INIT_SIDO = '서울';
 export const INIT_CITY = '강남구';

--- a/src/utils/constants/dust.ts
+++ b/src/utils/constants/dust.ts
@@ -2,6 +2,7 @@ import type { GradeType } from '@/types/dust';
 
 export const FINE_DUST = '미세먼지';
 export const ULTRA_FINE_DUST = '초미세먼지';
+export const KIND_OF_DUST = [FINE_DUST, ULTRA_FINE_DUST];
 
 export const DUST_GRADE: { [key: number]: GradeType } = {
   0: 'NONE',

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -1,6 +1,16 @@
-export { SIDO_GROUP, INIT_SIDO, INIT_CITY } from '@/utils/constants/city';
+export {
+  SIDO_GROUP,
+  INIT_SIDO,
+  INIT_CITY,
+  SIDO_NAMES,
+} from '@/utils/constants/city';
 export { INIT_LOCATION, CENTER_LOCATION } from '@/utils/constants/location';
-export { FINE_DUST, ULTRA_FINE_DUST, DUST_GRADE } from '@/utils/constants/dust';
+export {
+  FINE_DUST,
+  ULTRA_FINE_DUST,
+  DUST_GRADE,
+  KIND_OF_DUST,
+} from '@/utils/constants/dust';
 export { ROUTE } from '@/utils/constants/route';
 export {
   INIT_ZOOM_LEVEL,


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #147 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- city Ranking 페이지에서 시/도 선택 변경시 배경이 깜빡 거리던 현상을 수정합니다.
## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
[chrome-capture-2023-4-20.webm](https://github.com/tooooo1/dust-rating/assets/12118892/d0d2045e-b213-4d85-bf2c-c290f27852df)


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 기존 Ranking 페이지가 2개로 분리되면서 city Ranking 페이지에는 수정사항이 반영되지 않았던 점을 수정했습니다.
- Sido Ranking 페이지와 City Ranking 페이지에서 공통적으로 사용하는 배열을 상수화 했습니다.
## 질문 <!-- 궁금한 부분을 적어주세요 -->
