### PR TITLE
feat: NaviBar 적용

### DIFF
--- a/src/components/Map/ControlButton.tsx
+++ b/src/components/Map/ControlButton.tsx
@@ -1,5 +1,5 @@
 import { IconButton } from '@chakra-ui/react';
-import { AiOutlineFullscreenExit } from 'react-icons/ai';
+import { AiOutlineFullscreenExit, AiOutlineArrowLeft } from 'react-icons/ai';
 import { BiTargetLock, BiPlus, BiMinus } from 'react-icons/bi';
 
 const icons = {
@@ -7,6 +7,7 @@ const icons = {
   'zoom-in': <BiPlus />,
   'zoom-out': <BiMinus />,
   'full-screen': <AiOutlineFullscreenExit />,
+  'go-back': <AiOutlineArrowLeft />,
 };
 
 type iconType = keyof typeof icons;

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -245,6 +245,10 @@ const Map = () => {
     );
   };
 
+  const handleClickGoBack = () => {
+    navigate(-1);
+  };
+
   useEffect(() => {
     document
       .querySelectorAll<HTMLDivElement>('.dust-info-marker')
@@ -289,6 +293,7 @@ const Map = () => {
           type="full-screen"
           onClick={() => handleFullScreenChange(cityDustInfoMarkers)}
         />
+        <ControlButton type="go-back" onClick={handleClickGoBack} />
         {zoomLevel === MAX_ZOOM_LEVEL && sidoDustInfosIsLoading && <Spinner />}
       </VStack>
       {cityDustInfosIsLoading ? <Spinner zIndex={10} /> : ''}

--- a/src/components/Nav/NavButton.tsx
+++ b/src/components/Nav/NavButton.tsx
@@ -1,7 +1,12 @@
-import { Flex } from '@chakra-ui/react';
+import { Flex, useMediaQuery } from '@chakra-ui/react';
 import { MotionStyle, motion } from 'framer-motion';
 import { useState } from 'react';
-import { AiOutlineMenuFold, AiOutlineArrowLeft } from 'react-icons/ai';
+import {
+  AiOutlineMenuFold,
+  AiOutlineArrowLeft,
+  AiOutlineHome,
+} from 'react-icons/ai';
+import { BiMap } from 'react-icons/bi';
 import { useNavigate } from 'react-router-dom';
 import { NavListItem } from '@/components/Nav';
 import { ROUTE } from '@/utils/constants';
@@ -15,6 +20,7 @@ const ICON_SIZE = '2rem';
 export const NavButton = ({ styleProps }: NaviButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
+  const [isLargerThan480] = useMediaQuery('(min-width: 480px)');
 
   const handleClick = () => {
     setIsOpen((prev) => !prev);
@@ -70,14 +76,18 @@ export const NavButton = ({ styleProps }: NaviButtonProps) => {
               duration: 0.7,
               delayChildren: 0.3,
               staggerChildren: 0.05,
+              staggerDirection: -1,
             },
           },
           closed: {
-            clipPath: 'inset(10% 50% 90% 50% round 10px)',
+            clipPath: 'inset(0% 0% 0% 0% round 10px)',
             transition: {
               type: 'spring',
               bounce: 0,
               duration: 0.3,
+              delayChildren: 0.3,
+              staggerChildren: 0.05,
+              staggerDirection: 1,
             },
           },
         }}
@@ -89,16 +99,16 @@ export const NavButton = ({ styleProps }: NaviButtonProps) => {
         }}
       >
         <NavListItem variants={itemVariants} handleClick={handleClickMainPage}>
-          메인 화면
+          {isLargerThan480 ? '메인 화면' : <AiOutlineHome />}
         </NavListItem>
         <NavListItem
           variants={itemVariants}
           handleClick={handleClickSidoRankingPage}
         >
-          전국 랭킹
+          {isLargerThan480 ? '전국 랭킹' : '전국'}
         </NavListItem>
         <NavListItem variants={itemVariants} handleClick={handleClickMapPage}>
-          전국 지도
+          {isLargerThan480 ? '전국 지도' : <BiMap />}
         </NavListItem>
       </motion.ul>
       <motion.button whileTap={{ scale: 0.97 }} onClick={handleClick}>

--- a/src/components/Nav/NavButton.tsx
+++ b/src/components/Nav/NavButton.tsx
@@ -1,8 +1,9 @@
-import { Button, Flex } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 import { MotionStyle, motion } from 'framer-motion';
 import { useState } from 'react';
 import { AiOutlineMenuFold, AiOutlineArrowLeft } from 'react-icons/ai';
 import { useNavigate } from 'react-router-dom';
+import { NavListItem } from '@/components/Nav';
 import { ROUTE } from '@/utils/constants';
 
 interface NaviButtonProps {
@@ -11,7 +12,7 @@ interface NaviButtonProps {
 
 const ICON_SIZE = '2rem';
 
-export const NaviButton = ({ styleProps }: NaviButtonProps) => {
+export const NavButton = ({ styleProps }: NaviButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
 
@@ -87,15 +88,18 @@ export const NaviButton = ({ styleProps }: NaviButtonProps) => {
           justifyContent: 'space-around',
         }}
       >
-        <motion.li variants={itemVariants}>
-          <Button onClick={handleClickMainPage}>메인 화면</Button>
-        </motion.li>
-        <motion.li variants={itemVariants}>
-          <Button onClick={handleClickSidoRankingPage}>전국 랭킹</Button>
-        </motion.li>
-        <motion.li variants={itemVariants}>
-          <Button onClick={handleClickMapPage}>전국 지도</Button>
-        </motion.li>
+        <NavListItem variants={itemVariants} handleClick={handleClickMainPage}>
+          메인 화면
+        </NavListItem>
+        <NavListItem
+          variants={itemVariants}
+          handleClick={handleClickSidoRankingPage}
+        >
+          전국 랭킹
+        </NavListItem>
+        <NavListItem variants={itemVariants} handleClick={handleClickMapPage}>
+          전국 지도
+        </NavListItem>
       </motion.ul>
       <motion.button whileTap={{ scale: 0.97 }} onClick={handleClick}>
         <Flex>
@@ -106,4 +110,4 @@ export const NaviButton = ({ styleProps }: NaviButtonProps) => {
   );
 };
 
-export default NaviButton;
+export default NavButton;

--- a/src/components/Nav/NavButton.tsx
+++ b/src/components/Nav/NavButton.tsx
@@ -111,11 +111,14 @@ export const NavButton = ({ styleProps }: NaviButtonProps) => {
           {isLargerThan480 ? '전국 지도' : <BiMap />}
         </NavListItem>
       </motion.ul>
-      <motion.button whileTap={{ scale: 0.97 }} onClick={handleClick}>
-        <Flex>
-          <AiOutlineMenuFold className="nav-icon" size={ICON_SIZE} />
-        </Flex>
-      </motion.button>
+      <Flex
+        flexDirection="column"
+        justifyContent="center"
+        onClick={handleClick}
+        cursor="pointer"
+      >
+        <AiOutlineMenuFold className="nav-icon" size={ICON_SIZE} />
+      </Flex>
     </motion.nav>
   );
 };

--- a/src/components/Nav/NavListItem.tsx
+++ b/src/components/Nav/NavListItem.tsx
@@ -1,0 +1,24 @@
+import { Button } from '@chakra-ui/react';
+import { Variants, motion } from 'framer-motion';
+import { PropsWithChildren } from 'react';
+
+interface NavListItemProps {
+  variants: Variants;
+  handleClick: () => void;
+}
+
+export const NavListItem = ({
+  variants,
+  handleClick,
+  children,
+}: PropsWithChildren<NavListItemProps>) => {
+  return (
+    <motion.li variants={variants}>
+      <Button _hover={{ bg: '#ffffff8f' }} onClick={handleClick}>
+        {children}
+      </Button>
+    </motion.li>
+  );
+};
+
+export default NavListItem;

--- a/src/components/Nav/index.ts
+++ b/src/components/Nav/index.ts
@@ -1,0 +1,2 @@
+export { default as NavButton } from '@/components/Nav/NavButton';
+export { default as NavListItem } from '@/components/Nav/NavListItem';

--- a/src/components/common/NaviButton.tsx
+++ b/src/components/common/NaviButton.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTE } from '@/utils/constants';
 
 interface NaviButtonProps {
-  sx?: MotionStyle;
+  styleProps?: MotionStyle;
 }
 
 const ICON = {
@@ -14,7 +14,7 @@ const ICON = {
   COLOR: '#ffffff',
 };
 
-export const NaviButton = ({ sx }: NaviButtonProps) => {
+export const NaviButton = ({ styleProps }: NaviButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
 
@@ -52,7 +52,7 @@ export const NaviButton = ({ sx }: NaviButtonProps) => {
       initial={false}
       animate={isOpen ? 'open' : 'closed'}
       className="menu"
-      style={{ ...sx }}
+      style={{ ...styleProps }}
     >
       <Box onClick={handleClickGoBack} cursor="pointer">
         <AiOutlineArrowLeft size={ICON.SIZE} color={ICON.COLOR} />

--- a/src/components/common/NaviButton.tsx
+++ b/src/components/common/NaviButton.tsx
@@ -1,4 +1,4 @@
-import { Box, Button } from '@chakra-ui/react';
+import { Button, Flex } from '@chakra-ui/react';
 import { MotionStyle, motion } from 'framer-motion';
 import { useState } from 'react';
 import { AiOutlineMenuFold, AiOutlineArrowLeft } from 'react-icons/ai';
@@ -9,10 +9,7 @@ interface NaviButtonProps {
   styleProps?: MotionStyle;
 }
 
-const ICON = {
-  SIZE: '2rem',
-  COLOR: '#ffffff',
-};
+const ICON_SIZE = '2rem';
 
 export const NaviButton = ({ styleProps }: NaviButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -54,9 +51,14 @@ export const NaviButton = ({ styleProps }: NaviButtonProps) => {
       className="menu"
       style={{ ...styleProps }}
     >
-      <Box onClick={handleClickGoBack} cursor="pointer">
-        <AiOutlineArrowLeft size={ICON.SIZE} color={ICON.COLOR} />
-      </Box>
+      <Flex
+        flexDirection="column"
+        justifyContent="center"
+        onClick={handleClickGoBack}
+        cursor="pointer"
+      >
+        <AiOutlineArrowLeft className="nav-icon" size={ICON_SIZE} />
+      </Flex>
       <motion.ul
         variants={{
           open: {
@@ -96,9 +98,9 @@ export const NaviButton = ({ styleProps }: NaviButtonProps) => {
         </motion.li>
       </motion.ul>
       <motion.button whileTap={{ scale: 0.97 }} onClick={handleClick}>
-        <Box>
-          <AiOutlineMenuFold size={ICON.SIZE} color={ICON.COLOR} />
-        </Box>
+        <Flex>
+          <AiOutlineMenuFold className="nav-icon" size={ICON_SIZE} />
+        </Flex>
       </motion.button>
     </motion.nav>
   );

--- a/src/components/common/NaviButton.tsx
+++ b/src/components/common/NaviButton.tsx
@@ -1,0 +1,102 @@
+import { Button } from '@chakra-ui/react';
+import { MotionStyle, motion } from 'framer-motion';
+import { useState } from 'react';
+import { AiOutlineMenuFold } from 'react-icons/ai';
+import { useNavigate } from 'react-router-dom';
+import { ROUTE } from '@/utils/constants';
+
+interface NaviButtonProps {
+  sx?: MotionStyle;
+}
+
+export const NaviButton = ({ sx }: NaviButtonProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleClickMainPage = () => {
+    navigate(ROUTE.HOME);
+  };
+
+  const handleClickSidoRankingPage = () => {
+    navigate(ROUTE.SIDO_RANKING);
+  };
+
+  const handleClickMapPage = () => {
+    navigate(ROUTE.DUST_MAP);
+  };
+
+  const itemVariants = {
+    open: {
+      opacity: 1,
+      y: 0,
+      transition: { type: 'spring', stiffness: 300, damping: 24 },
+    },
+    closed: { opacity: 0, y: 20, transition: { duration: 0.2 } },
+  };
+
+  return (
+    <motion.nav
+      initial={false}
+      animate={isOpen ? 'open' : 'closed'}
+      className="menu"
+      style={{ ...sx }}
+    >
+      <motion.ul
+        variants={{
+          open: {
+            clipPath: 'inset(0% 0% 0% 0% round 10px)',
+            transition: {
+              type: 'spring',
+              bounce: 0,
+              duration: 0.7,
+              delayChildren: 0.3,
+              staggerChildren: 0.05,
+            },
+          },
+          closed: {
+            clipPath: 'inset(10% 50% 90% 50% round 10px)',
+            transition: {
+              type: 'spring',
+              bounce: 0,
+              duration: 0.3,
+            },
+          },
+        }}
+        style={{
+          pointerEvents: isOpen ? 'auto' : 'none',
+          minWidth: '30%',
+          display: 'flex',
+          justifyContent: 'space-around',
+        }}
+      >
+        <motion.li variants={itemVariants}>
+          <Button onClick={handleClickMainPage}>메인 화면</Button>
+        </motion.li>
+        <motion.li variants={itemVariants}>
+          <Button onClick={handleClickSidoRankingPage}>전국 랭킹</Button>
+        </motion.li>
+        <motion.li variants={itemVariants}>
+          <Button onClick={handleClickMapPage}>전국 지도</Button>
+        </motion.li>
+      </motion.ul>
+      <motion.button whileTap={{ scale: 0.97 }} onClick={handleClick}>
+        <motion.div
+          variants={{
+            open: { rotate: 0 },
+            closed: { rotate: 180 },
+          }}
+          transition={{ duration: 0.2 }}
+          style={{ originY: 0.55 }}
+        >
+          <AiOutlineMenuFold />
+        </motion.div>
+      </motion.button>
+    </motion.nav>
+  );
+};
+
+export default NaviButton;

--- a/src/components/common/NaviButton.tsx
+++ b/src/components/common/NaviButton.tsx
@@ -9,6 +9,11 @@ interface NaviButtonProps {
   sx?: MotionStyle;
 }
 
+const ICON = {
+  SIZE: '2rem',
+  COLOR: '#ffffff',
+};
+
 export const NaviButton = ({ sx }: NaviButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
@@ -50,7 +55,7 @@ export const NaviButton = ({ sx }: NaviButtonProps) => {
       style={{ ...sx }}
     >
       <Box onClick={handleClickGoBack} cursor="pointer">
-        <AiOutlineArrowLeft size="2rem" color="white" />
+        <AiOutlineArrowLeft size={ICON.SIZE} color={ICON.COLOR} />
       </Box>
       <motion.ul
         variants={{
@@ -91,9 +96,9 @@ export const NaviButton = ({ sx }: NaviButtonProps) => {
         </motion.li>
       </motion.ul>
       <motion.button whileTap={{ scale: 0.97 }} onClick={handleClick}>
-        <motion.div>
-          <AiOutlineMenuFold size="2rem" color="white" />
-        </motion.div>
+        <Box>
+          <AiOutlineMenuFold size={ICON.SIZE} color={ICON.COLOR} />
+        </Box>
       </motion.button>
     </motion.nav>
   );

--- a/src/components/common/NaviButton.tsx
+++ b/src/components/common/NaviButton.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@chakra-ui/react';
+import { Box, Button } from '@chakra-ui/react';
 import { MotionStyle, motion } from 'framer-motion';
 import { useState } from 'react';
-import { AiOutlineMenuFold } from 'react-icons/ai';
+import { AiOutlineMenuFold, AiOutlineArrowLeft } from 'react-icons/ai';
 import { useNavigate } from 'react-router-dom';
 import { ROUTE } from '@/utils/constants';
 
@@ -29,6 +29,10 @@ export const NaviButton = ({ sx }: NaviButtonProps) => {
     navigate(ROUTE.DUST_MAP);
   };
 
+  const handleClickGoBack = () => {
+    navigate(-1);
+  };
+
   const itemVariants = {
     open: {
       opacity: 1,
@@ -45,6 +49,9 @@ export const NaviButton = ({ sx }: NaviButtonProps) => {
       className="menu"
       style={{ ...sx }}
     >
+      <Box onClick={handleClickGoBack} cursor="pointer">
+        <AiOutlineArrowLeft size="2rem" color="white" />
+      </Box>
       <motion.ul
         variants={{
           open: {
@@ -84,15 +91,8 @@ export const NaviButton = ({ sx }: NaviButtonProps) => {
         </motion.li>
       </motion.ul>
       <motion.button whileTap={{ scale: 0.97 }} onClick={handleClick}>
-        <motion.div
-          variants={{
-            open: { rotate: 0 },
-            closed: { rotate: 180 },
-          }}
-          transition={{ duration: 0.2 }}
-          style={{ originY: 0.55 }}
-        >
-          <AiOutlineMenuFold />
+        <motion.div>
+          <AiOutlineMenuFold size="2rem" color="white" />
         </motion.div>
       </motion.button>
     </motion.nav>

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -5,3 +5,4 @@ export { default as DustState } from '@/components/common/DustState';
 export { default as ErrorFallback } from '@/components/common/ErrorFallback';
 export { default as Rank } from '@/components/common/Rank';
 export { default as ListFallback } from '@/components/common/ListFallback';
+export { default as NaviButton } from '@/components/common/NaviButton';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -5,4 +5,4 @@ export { default as DustState } from '@/components/common/DustState';
 export { default as ErrorFallback } from '@/components/common/ErrorFallback';
 export { default as Rank } from '@/components/common/Rank';
 export { default as ListFallback } from '@/components/common/ListFallback';
-export { default as NaviButton } from '@/components/common/NaviButton';
+export { default as NaviButton } from '@/components/Nav/NavButton';

--- a/src/pages/CityRanking.tsx
+++ b/src/pages/CityRanking.tsx
@@ -69,7 +69,7 @@ const CityRanking = () => {
       backgroundSize="200% 200%"
     >
       <NaviButton
-        sx={{
+        styleProps={{
           marginTop: 10,
           display: 'flex',
           justifyContent: 'center',

--- a/src/pages/CityRanking.tsx
+++ b/src/pages/CityRanking.tsx
@@ -10,6 +10,7 @@ import {
   DustState,
   ListFallback,
 } from '@/components/common';
+import NaviButton from '@/components/common/NaviButton';
 import { SelectList, CityRankList } from '@/components/Ranking';
 import theme from '@/styles/theme';
 import type { SortType } from '@/types/dust';
@@ -67,12 +68,20 @@ const CityRanking = () => {
       textAlign="center"
       backgroundSize="200% 200%"
     >
+      <NaviButton
+        sx={{
+          marginTop: 10,
+          display: 'flex',
+          justifyContent: 'center',
+          minWidth: '10%',
+        }}
+      />
       <Text
         as="h1"
         fontSize={{ base: 18, sm: 20, md: 24 }}
         fontWeight={600}
         color="#ffffff"
-        mt={20}
+        mt={10}
         mb={{ base: 2, sm: 3, md: 4 }}
       >
         전국 미세 먼지 농도는 다음과 같습니다

--- a/src/pages/CityRanking.tsx
+++ b/src/pages/CityRanking.tsx
@@ -10,7 +10,7 @@ import {
   DustState,
   ListFallback,
 } from '@/components/common';
-import NaviButton from '@/components/common/NaviButton';
+import NaviButton from '@/components/Nav/NavButton';
 import { SelectList, CityRankList } from '@/components/Ranking';
 import theme from '@/styles/theme';
 import type { SortType } from '@/types/dust';

--- a/src/pages/DustForecast.tsx
+++ b/src/pages/DustForecast.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { useSearchParams } from 'react-router-dom';
 import { getCityDustInfos } from '@/apis/dustInfo';
-import { AsyncBoundary, DustLevel } from '@/components/common';
+import { AsyncBoundary, DustLevel, NaviButton } from '@/components/common';
 import {
   CurrentDustInfo,
   DustChart,
@@ -57,6 +57,14 @@ const DustForecast = () => {
       textAlign="center"
       backgroundSize="200% 200%"
     >
+      <NaviButton
+        styleProps={{
+          marginTop: 10,
+          display: 'flex',
+          justifyContent: 'center',
+          minWidth: '10%',
+        }}
+      />
       <Text
         as="h1"
         fontSize={{ base: 18, sm: 20, md: 24 }}

--- a/src/pages/SidoRanking.tsx
+++ b/src/pages/SidoRanking.tsx
@@ -43,7 +43,7 @@ const SidoRanking = () => {
       textAlign="center"
     >
       <NaviButton
-        sx={{
+        styleProps={{
           marginTop: 10,
           display: 'flex',
           justifyContent: 'center',

--- a/src/pages/SidoRanking.tsx
+++ b/src/pages/SidoRanking.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { ChangeEvent, useState } from 'react';
 import { getSidoDustInfo } from '@/apis/dustInfo';
-import { AsyncBoundary, ListFallback } from '@/components/common';
+import { AsyncBoundary, ListFallback, NaviButton } from '@/components/common';
 import { SelectList, SidoRankList } from '@/components/Ranking';
 import theme from '@/styles/theme';
 import {
@@ -42,6 +42,14 @@ const SidoRanking = () => {
       bgGradient={theme.backgroundColors['INIT']}
       textAlign="center"
     >
+      <NaviButton
+        sx={{
+          marginTop: 10,
+          display: 'flex',
+          justifyContent: 'center',
+          minWidth: '10%',
+        }}
+      />
       <Text
         as="h1"
         fontSize={{ base: 18, sm: 20, md: 24 }}

--- a/src/styles/globalStyle.css
+++ b/src/styles/globalStyle.css
@@ -48,3 +48,11 @@
   margin-bottom: 0.2rem;
   color: #2a282f;
 }
+
+.nav-icon {
+  color: #ffffff;
+}
+
+.nav-icon:hover {
+  color: #ffffff8f;
+}


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #149

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 메인, 지도 페이지를 제외한 모든 페이지에 NaviBar가 적용됩니다. 지도 페이지에는 뒤로 가기 버튼만 추가되었습니다. 이제 페이지 내에서 클릭만을 통해서 모든 페이지를 왔다 갔다 할 수 있습니다! 야호!

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
[chrome-capture-2023-4-20.webm](https://github.com/tooooo1/dust-rating/assets/12118892/304eca6a-074f-47ed-ab41-7421501ff9a9)


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- ~~아직 merge 되지 않은 branch의 작업들을 pull 한 뒤 작업해서 중복되는 file change가 많을 것 같습니다. 그래서 이전 pr이 merge 되면 해당 pr을 최신화 하고 활성화 할 계획인데 그래도 중복되는 file Change이 많다면......죄송합니다.~~
오! 이전 pr merge 되고 해당 pr에 pull 해주니까  file change가 17에서 10으로 줄어들었네요!
- 애니메이션 적용이 처음이라 어떤지 모르겠네요. (코드 측면에서도 잘 작성된 건지 잘 모르겠습니다 의견주세요!)

## 질문 <!-- 궁금한 부분을 적어주세요 -->
- 프로젝트를 진행하면서 구현한 컴포넌트가 아니고 2번 이상 반복되는 코드들은 컴포넌트나 상수로 사용하자고 기준을 잡고 있습니다. 이번 PR 에서는 NavListItem.tsx가 대표적인 예가 되겠네요. 지금 당장 가독성이나 코드 길이에서 차이가 나지 않더라도 추후에 관리가 편할거라는 생각이 들어서 이렇게 진행하고 있는데 '배보다 배꼽이 더 커지나?' 하는 생각도 드네요! 여러분의 생각은 어떠신가요?
- ```src/components/Nav/NavButton.tsx```의   61줄, 114줄의 경우 같은 내용이 2번 반복되지만 위와 같은 고민을 해보느라 따로 컴포넌트로 만들지 않았습니당. 
