### PR TITLE
style: 랭킹 리스트 라인 정렬

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -323,7 +323,6 @@ const Map = () => {
             <MarkerModalButton handleClick={handleClickForeCastButton}>
               예보 페이지로 이동하기
             </MarkerModalButton>
-            <MarkerModalButton handleClick={onClose}>닫기</MarkerModalButton>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -282,6 +282,9 @@ const Map = () => {
           height: '100%',
         }}
       />
+      <Box position="absolute" top="1rem" left="1rem" zIndex={10}>
+        <ControlButton type="go-back" onClick={handleClickGoBack} />
+      </Box>
       <VStack position="absolute" top="1rem" right="1rem" zIndex={10}>
         <ControlButton
           type="current-location"
@@ -293,7 +296,6 @@ const Map = () => {
           type="full-screen"
           onClick={() => handleFullScreenChange(cityDustInfoMarkers)}
         />
-        <ControlButton type="go-back" onClick={handleClickGoBack} />
         {zoomLevel === MAX_ZOOM_LEVEL && sidoDustInfosIsLoading && <Spinner />}
       </VStack>
       {cityDustInfosIsLoading ? <Spinner zIndex={10} /> : ''}

--- a/src/components/Nav/NavButton.tsx
+++ b/src/components/Nav/NavButton.tsx
@@ -17,7 +17,7 @@ interface NaviButtonProps {
 
 export const NavButton = ({ styleProps }: NaviButtonProps) => {
   const navigate = useNavigate();
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
   const [isLargerThan480] = useMediaQuery('(min-width: 480px)');
 
   const handleClick = () => {

--- a/src/components/common/Rank.tsx
+++ b/src/components/common/Rank.tsx
@@ -30,6 +30,7 @@ const Rank = ({ rank, title, dustFigures }: RankProps) => {
         overflow="hidden"
         whiteSpace="nowrap"
         textOverflow="ellipsis"
+        title={title.length > 7 ? title : ''}
       >
         {title}
       </Text>

--- a/src/components/common/Rank.tsx
+++ b/src/components/common/Rank.tsx
@@ -18,6 +18,7 @@ const Rank = ({ rank, title, dustFigures }: RankProps) => {
         fontWeight={400}
         mr={4}
         color="#9dadb6"
+        width="8%"
       >
         {rank}
       </Text>

--- a/src/styles/globalStyle.css
+++ b/src/styles/globalStyle.css
@@ -32,6 +32,10 @@
   border-radius: 2rem;
 }
 
+.dust-info-marker:hover {
+  cursor: pointer;
+}
+
 .dust-info {
   display: flex;
   font-size: 0.8rem;


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #164 
- close #109

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 랭킹 페이지 -> 랭킹 리스트 라인 맞추기
- 지도 페이지 -> 모달 하단 닫기 버튼 삭제
- 지도 페이지 -> 이전 버튼 위치 변경
- 지도 페이지 -> 지도 커서 모양
- nav bar가 기본적으로 열려있게 했습니다.
- 긴 지명에 hover시 확인가능.
## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://github.com/tooooo1/dust-rating/assets/12118892/13b0486c-ca0b-4663-af82-5ec9e4760598)
![image](https://github.com/tooooo1/dust-rating/assets/12118892/499fadf2-f6d9-44ac-9cd2-d3d623e3dccb)
![image](https://github.com/tooooo1/dust-rating/assets/12118892/cb6e0087-c641-4773-aca8-d9f3b90c9085)
![image](https://github.com/tooooo1/dust-rating/assets/12118892/4889e843-0680-4859-8b99-122ce13220c9)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 질문 <!-- 궁금한 부분을 적어주세요 -->
