### PR TITLE
fix: 초미세먼지 탭을 눌러도 이미지가 변경되지 않는 문제 해결하기

### DIFF
--- a/src/apis/dustForecast.ts
+++ b/src/apis/dustForecast.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
-import type { DustCode } from '@/types/dust';
-import { FINE_DUST_CODE, ULTRA_FINE_DUST_CODE } from '@/utils/constants';
+import type { DustCode, DustImgCode } from '@/types/dust';
+import {
+  FINE_DUST_CODE,
+  FINE_DUST_IMG_CODE,
+  ULTRA_FINE_DUST_CODE,
+  ULTRA_FINE_DUST_IMG_CODE,
+} from '@/utils/constants';
 import { getTodayDate } from '@/utils/formaters';
 
 const { VITE_DUST_FORECAST_URL, VITE_DUST_INFO_API_KEY } = import.meta.env;
@@ -14,6 +19,12 @@ interface DustForecastData {
   informOverall: string;
   informData: string;
 }
+
+const getImage = (dustForecast: DustForecastData, dustImgCode: DustImgCode) => {
+  return Object.values(dustForecast).find(
+    (value) => typeof value === 'string' && value.includes(dustImgCode)
+  );
+};
 
 const getGifImage = (dustForecast: DustForecastData): string => {
   return Object.values(dustForecast).find(
@@ -65,14 +76,14 @@ export const getDustForecast = async () => {
 
     return {
       fineDust: {
-        imageSrc: fineDust.imageUrl1,
+        imageSrc: getImage(fineDust, FINE_DUST_IMG_CODE),
         gifImageSrc: getGifImage(fineDust),
         informCause: fineDust.informCause,
         informOverall: fineDust.informOverall,
         date: fineDust.informData,
       },
       ultraFineDust: {
-        imageSrc: ultraFineDust.imageUrl1,
+        imageSrc: getImage(ultraFineDust, ULTRA_FINE_DUST_IMG_CODE),
         gifImageSrc: getGifImage(ultraFineDust),
         informCause: ultraFineDust.informCause,
         informOverall: ultraFineDust.informOverall,

--- a/src/types/dust.ts
+++ b/src/types/dust.ts
@@ -1,16 +1,21 @@
 import {
   FINE_DUST,
-  ULTRA_FINE_DUST,
   FINE_DUST_CODE,
+  FINE_DUST_IMG_CODE,
+  ULTRA_FINE_DUST,
   ULTRA_FINE_DUST_CODE,
+  ULTRA_FINE_DUST_IMG_CODE,
 } from '@/utils/constants';
 
 type Flag = null | '통신장애';
 
-export type SortType = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 export type GradeType = 'NONE' | 'GOOD' | 'NORMAL' | 'BAD' | 'DANGER';
 
+export type SortType = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 export type DustCode = typeof FINE_DUST_CODE | typeof ULTRA_FINE_DUST_CODE;
+export type DustImgCode =
+  | typeof FINE_DUST_IMG_CODE
+  | typeof ULTRA_FINE_DUST_IMG_CODE;
 
 export interface DustScale {
   pm10Value: string;

--- a/src/utils/constants/dust.ts
+++ b/src/utils/constants/dust.ts
@@ -7,6 +7,9 @@ export const KIND_OF_DUST = [FINE_DUST, ULTRA_FINE_DUST];
 export const FINE_DUST_CODE = 'PM10';
 export const ULTRA_FINE_DUST_CODE = 'PM25';
 
+export const FINE_DUST_IMG_CODE = 'PM10';
+export const ULTRA_FINE_DUST_IMG_CODE = 'PM2P5';
+
 export const INIT_DATATIME = '0000-00-00 00:00';
 
 export const DUST_GRADE: { [key: number]: GradeType } = {

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -2,9 +2,11 @@ export { SIDO_NAMES, INIT_SIDO, INIT_CITY } from '@/utils/constants/city';
 export { INIT_LOCATION, CENTER_LOCATION } from '@/utils/constants/location';
 export {
   FINE_DUST,
-  ULTRA_FINE_DUST,
   FINE_DUST_CODE,
+  FINE_DUST_IMG_CODE,
+  ULTRA_FINE_DUST,
   ULTRA_FINE_DUST_CODE,
+  ULTRA_FINE_DUST_IMG_CODE,
   DUST_GRADE,
   KIND_OF_DUST,
   INIT_DATATIME,


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #174 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 초미세먼지 예보 png 이미지 가져오기

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
- 개선 전

https://github.com/tooooo1/dust-rating/assets/76807107/5f507364-8654-403f-8565-e628dbc57dcd

- 개선 후

https://github.com/tooooo1/dust-rating/assets/76807107/2d7884d2-dad3-407c-8c78-eb3f36539e30


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 두 가지 탭에 모두 '미세먼지' 이미지만 사용하고 있던 문제 해결...

## 질문 <!-- 궁금한 부분을 적어주세요 -->
