### PR TITLE
feat: 정렬 기준에 내림차순, 오름차순 추가

### DIFF
--- a/src/components/Ranking/CityRankList.tsx
+++ b/src/components/Ranking/CityRankList.tsx
@@ -10,11 +10,11 @@ interface CityRankListProps {
 }
 
 const CityRankList = ({ sido }: CityRankListProps) => {
-  const { sortType } = useSort();
+  const { dustType } = useSort();
 
   const cityDustInfoList = useCityDustInfoListQuery(sido, {
     select: (data: CityDustInfo[]) =>
-      sortDustList<CityDustInfo>(sortType, data),
+      sortDustList<CityDustInfo>(dustType, data),
     suspense: true,
   });
 

--- a/src/components/Ranking/CityRankList.tsx
+++ b/src/components/Ranking/CityRankList.tsx
@@ -10,11 +10,11 @@ interface CityRankListProps {
 }
 
 const CityRankList = ({ sido }: CityRankListProps) => {
-  const { dustType } = useSort();
+  const { dustType, sortType } = useSort();
 
   const cityDustInfoList = useCityDustInfoListQuery(sido, {
     select: (data: CityDustInfo[]) =>
-      sortDustList<CityDustInfo>(dustType, data),
+      sortDustList<CityDustInfo>(dustType, sortType, data),
     suspense: true,
   });
 

--- a/src/components/Ranking/RankingContent.tsx
+++ b/src/components/Ranking/RankingContent.tsx
@@ -6,7 +6,7 @@ import {
   ListFallback,
 } from '@/components/common';
 import { useSort } from '@/store/sort';
-import { KIND_OF_DUST, ERROR_MESSAGE } from '@/utils/constants';
+import { KIND_OF_DUST, ERROR_MESSAGE, SORT_TYPE } from '@/utils/constants';
 import SelectTabList from './SelectTabList';
 
 interface RankingContentProps {

--- a/src/components/Ranking/RankingContent.tsx
+++ b/src/components/Ranking/RankingContent.tsx
@@ -46,8 +46,12 @@ const RankingContent = ({
       >
         지역별 {dustType} 농도 순위
       </Text>
-      <SelectTabList selectTabList={KIND_OF_DUST} onClick={setDustType} />
-      <SelectTabList selectTabList={SORT_TYPE} onClick={setSortType} />
+      <SelectTabList
+        selectTabList={KIND_OF_DUST}
+        handleClickTab={setDustType}
+        selectOption={SORT_TYPE}
+        handleClickOption={setSortType}
+      />
       <AsyncBoundary
         rejectFallback={
           <ErrorFallback errorMessage="지역별 미세먼지 정보를 불러오지 못했어요." />

--- a/src/components/Ranking/RankingContent.tsx
+++ b/src/components/Ranking/RankingContent.tsx
@@ -6,7 +6,7 @@ import {
   ListFallback,
 } from '@/components/common';
 import { useSort } from '@/store/sort';
-import { KIND_OF_DUST } from '@/utils/constants';
+import { KIND_OF_DUST, SORT_TYPE } from '@/utils/constants';
 import SelectTabList from './SelectTabList';
 
 interface RankingContentProps {
@@ -17,7 +17,7 @@ const RankingContent = ({
   children,
   backgroundColor,
 }: PropsWithChildren<RankingContentProps>) => {
-  const { dustType } = useSort();
+  const { dustType, setDustType, setSortType } = useSort();
 
   return (
     <Flex
@@ -46,7 +46,8 @@ const RankingContent = ({
       >
         지역별 {dustType} 농도 순위
       </Text>
-      <SelectTabList selectTabList={KIND_OF_DUST} />
+      <SelectTabList selectTabList={KIND_OF_DUST} onClick={setDustType} />
+      <SelectTabList selectTabList={SORT_TYPE} onClick={setSortType} />
       <AsyncBoundary
         rejectFallback={
           <ErrorFallback errorMessage="지역별 미세먼지 정보를 불러오지 못했어요." />

--- a/src/components/Ranking/RankingContent.tsx
+++ b/src/components/Ranking/RankingContent.tsx
@@ -17,7 +17,7 @@ const RankingContent = ({
   children,
   backgroundColor,
 }: PropsWithChildren<RankingContentProps>) => {
-  const { sortType } = useSort();
+  const { dustType } = useSort();
 
   return (
     <Flex
@@ -44,7 +44,7 @@ const RankingContent = ({
         bg={backgroundColor}
         transition="all 500ms ease-in-out"
       >
-        지역별 {sortType} 농도 순위
+        지역별 {dustType} 농도 순위
       </Text>
       <SelectTabList selectTabList={KIND_OF_DUST} />
       <AsyncBoundary

--- a/src/components/Ranking/RankingHeader.tsx
+++ b/src/components/Ranking/RankingHeader.tsx
@@ -7,7 +7,7 @@ interface RankingHeaderProps {
 }
 
 const RankingHeader = ({ dataTime }: RankingHeaderProps) => {
-  const { sortType: dustType } = useSort();
+  const { dustType: dustType } = useSort();
 
   return (
     <>

--- a/src/components/Ranking/SelectTabList.tsx
+++ b/src/components/Ranking/SelectTabList.tsx
@@ -6,7 +6,7 @@ interface SelectTabListProps {
 }
 
 export const SelectTabList = ({ selectTabList }: SelectTabListProps) => {
-  const { setSortType } = useSort();
+  const { setDustType } = useSort();
 
   return (
     <Tabs
@@ -22,7 +22,7 @@ export const SelectTabList = ({ selectTabList }: SelectTabListProps) => {
             key={tabItem}
             value={tabItem}
             fontSize={{ base: 14, sm: 16 }}
-            onClick={setSortType}
+            onClick={setDustType}
           >
             {tabItem}
           </Tab>

--- a/src/components/Ranking/SelectTabList.tsx
+++ b/src/components/Ranking/SelectTabList.tsx
@@ -1,11 +1,16 @@
 import { Tabs, TabList, Tab } from '@chakra-ui/react';
 import { useSort } from '@/store/sort';
+import { MouseEvent } from 'react';
 
 interface SelectTabListProps {
   selectTabList: string[];
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
-export const SelectTabList = ({ selectTabList }: SelectTabListProps) => {
+export const SelectTabList = ({
+  selectTabList,
+  onClick,
+}: SelectTabListProps) => {
   const { setDustType } = useSort();
 
   return (
@@ -22,7 +27,7 @@ export const SelectTabList = ({ selectTabList }: SelectTabListProps) => {
             key={tabItem}
             value={tabItem}
             fontSize={{ base: 14, sm: 16 }}
-            onClick={setDustType}
+            onClick={onClick}
           >
             {tabItem}
           </Tab>

--- a/src/components/Ranking/SelectTabList.tsx
+++ b/src/components/Ranking/SelectTabList.tsx
@@ -11,8 +11,6 @@ export const SelectTabList = ({
   selectTabList,
   onClick,
 }: SelectTabListProps) => {
-  const { setDustType } = useSort();
-
   return (
     <Tabs
       width="100%"

--- a/src/components/Ranking/SelectTabList.tsx
+++ b/src/components/Ranking/SelectTabList.tsx
@@ -1,15 +1,18 @@
 import { Tabs, TabList, Tab } from '@chakra-ui/react';
-import { useSort } from '@/store/sort';
 import { MouseEvent } from 'react';
 
 interface SelectTabListProps {
   selectTabList: string[];
-  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+  handleClickTab: (e: MouseEvent<HTMLButtonElement>) => void;
+  selectOption?: string[];
+  handleClickOption?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const SelectTabList = ({
   selectTabList,
-  onClick,
+  handleClickTab,
+  selectOption,
+  handleClickOption,
 }: SelectTabListProps) => {
   return (
     <Tabs
@@ -25,12 +28,26 @@ export const SelectTabList = ({
             key={tabItem}
             value={tabItem}
             fontSize={{ base: 14, sm: 16 }}
-            onClick={onClick}
+            onClick={handleClickTab}
           >
             {tabItem}
           </Tab>
         ))}
       </TabList>
+      {selectOption && (
+        <TabList>
+          {selectOption.map((tabItem) => (
+            <Tab
+              key={tabItem}
+              value={tabItem}
+              fontSize={{ base: 14, sm: 16 }}
+              onClick={handleClickOption}
+            >
+              {tabItem}
+            </Tab>
+          ))}
+        </TabList>
+      )}
     </Tabs>
   );
 };

--- a/src/components/Ranking/SidoRankList.tsx
+++ b/src/components/Ranking/SidoRankList.tsx
@@ -5,10 +5,10 @@ import { sortDustList } from '@/utils/sortDustList';
 import RankItem from './RankItem';
 
 const SidoRankList = () => {
-  const { sortType } = useSort();
+  const { dustType } = useSort();
 
   const sidoDustInfoList = useSidoDustInfoListQuery({
-    select: (data) => sortDustList<SidoDustInfo>(sortType, data),
+    select: (data) => sortDustList<SidoDustInfo>(dustType, data),
     keepPreviousData: true,
     suspense: true,
   });

--- a/src/components/Ranking/SidoRankList.tsx
+++ b/src/components/Ranking/SidoRankList.tsx
@@ -5,10 +5,10 @@ import { sortDustList } from '@/utils/sortDustList';
 import RankItem from './RankItem';
 
 const SidoRankList = () => {
-  const { dustType } = useSort();
+  const { dustType, sortType } = useSort();
 
   const sidoDustInfoList = useSidoDustInfoListQuery({
-    select: (data) => sortDustList<SidoDustInfo>(dustType, data),
+    select: (data) => sortDustList<SidoDustInfo>(dustType, sortType, data),
     keepPreviousData: true,
     suspense: true,
   });

--- a/src/pages/CityRanking.tsx
+++ b/src/pages/CityRanking.tsx
@@ -106,6 +106,7 @@ const CityRanking = () => {
           theme.colors[DUST_GRADE[sidoDustInfo?.fineDustGrade || grade]]
         }
       >
+        {/* <Select options={['test', 'test2'] onClick={}}>test</Select> */}
         <CityRankList sido={place} />
       </RankingContent>
     </Flex>

--- a/src/pages/CityRanking.tsx
+++ b/src/pages/CityRanking.tsx
@@ -106,7 +106,6 @@ const CityRanking = () => {
           theme.colors[DUST_GRADE[sidoDustInfo?.fineDustGrade || grade]]
         }
       >
-        {/* <Select options={['test', 'test2'] onClick={}}>test</Select> */}
         <CityRankList sido={place} />
       </RankingContent>
     </Flex>

--- a/src/store/sort.tsx
+++ b/src/store/sort.tsx
@@ -5,18 +5,22 @@ import {
   MouseEvent,
   PropsWithChildren,
 } from 'react';
-import type { DustType } from '@/types/dust';
+import type { DustType, SortType } from '@/types/dust';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
 
 interface SortContextState {
   dustType: DustType;
+  sortType: SortType;
   setDustType: (e: MouseEvent<HTMLButtonElement>) => void;
+  setSortType: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
 const initialSortState: SortContextState = {
   dustType: FINE_DUST,
+  sortType: 'ASCENDING',
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   setDustType: () => {},
+  setSortType: () => {},
 };
 
 const SortContext = createContext<SortContextState>(initialSortState);
@@ -25,6 +29,7 @@ export const useSort = () => useContext(SortContext);
 
 const SortContextProvider = ({ children }: PropsWithChildren) => {
   const [dustType, setDustType] = useState<DustType>(FINE_DUST);
+  const [sortType, setSortType] = useState<SortType>('ASCENDING');
 
   const handleDustTypeChange = (e: MouseEvent<HTMLButtonElement>) => {
     setDustType(
@@ -32,9 +37,20 @@ const SortContextProvider = ({ children }: PropsWithChildren) => {
     );
   };
 
+  const handleSortTypeChnage = (e: MouseEvent<HTMLButtonElement>) => {
+    setSortType(
+      e.currentTarget.value === 'ASCENDING' ? 'ASCENDING' : 'DESCENDING'
+    );
+  };
+
   return (
     <SortContext.Provider
-      value={{ dustType, setDustType: handleDustTypeChange }}
+      value={{
+        dustType,
+        setDustType: handleDustTypeChange,
+        sortType,
+        setSortType: handleSortTypeChnage,
+      }}
     >
       {children}
     </SortContext.Provider>

--- a/src/store/sort.tsx
+++ b/src/store/sort.tsx
@@ -5,18 +5,18 @@ import {
   MouseEvent,
   PropsWithChildren,
 } from 'react';
-import type { SortType } from '@/types/dust';
+import type { DustType } from '@/types/dust';
 import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
 
 interface SortContextState {
-  sortType: SortType;
-  setSortType: (e: MouseEvent<HTMLButtonElement>) => void;
+  dustType: DustType;
+  setDustType: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
 const initialSortState: SortContextState = {
-  sortType: FINE_DUST,
+  dustType: FINE_DUST,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  setSortType: () => {},
+  setDustType: () => {},
 };
 
 const SortContext = createContext<SortContextState>(initialSortState);
@@ -24,17 +24,17 @@ const SortContext = createContext<SortContextState>(initialSortState);
 export const useSort = () => useContext(SortContext);
 
 const SortContextProvider = ({ children }: PropsWithChildren) => {
-  const [sortType, setSortType] = useState<SortType>(FINE_DUST);
+  const [dustType, setDustType] = useState<DustType>(FINE_DUST);
 
-  const handleSortTypeChange = (e: MouseEvent<HTMLButtonElement>) => {
-    setSortType(
+  const handleDustTypeChange = (e: MouseEvent<HTMLButtonElement>) => {
+    setDustType(
       e.currentTarget.value === FINE_DUST ? FINE_DUST : ULTRA_FINE_DUST
     );
   };
 
   return (
     <SortContext.Provider
-      value={{ sortType, setSortType: handleSortTypeChange }}
+      value={{ dustType, setDustType: handleDustTypeChange }}
     >
       {children}
     </SortContext.Provider>

--- a/src/store/sort.tsx
+++ b/src/store/sort.tsx
@@ -6,7 +6,12 @@ import {
   PropsWithChildren,
 } from 'react';
 import type { DustType, SortType } from '@/types/dust';
-import { FINE_DUST, ULTRA_FINE_DUST } from '@/utils/constants';
+import {
+  FINE_DUST,
+  ULTRA_FINE_DUST,
+  ASCENDING,
+  DESCENDING,
+} from '@/utils/constants';
 
 interface SortContextState {
   dustType: DustType;
@@ -17,7 +22,7 @@ interface SortContextState {
 
 const initialSortState: SortContextState = {
   dustType: FINE_DUST,
-  sortType: 'ASCENDING',
+  sortType: ASCENDING,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   setDustType: () => {},
   setSortType: () => {},
@@ -29,7 +34,7 @@ export const useSort = () => useContext(SortContext);
 
 const SortContextProvider = ({ children }: PropsWithChildren) => {
   const [dustType, setDustType] = useState<DustType>(FINE_DUST);
-  const [sortType, setSortType] = useState<SortType>('ASCENDING');
+  const [sortType, setSortType] = useState<SortType>(ASCENDING);
 
   const handleDustTypeChange = (e: MouseEvent<HTMLButtonElement>) => {
     setDustType(
@@ -38,9 +43,7 @@ const SortContextProvider = ({ children }: PropsWithChildren) => {
   };
 
   const handleSortTypeChnage = (e: MouseEvent<HTMLButtonElement>) => {
-    setSortType(
-      e.currentTarget.value === 'ASCENDING' ? 'ASCENDING' : 'DESCENDING'
-    );
+    setSortType(e.currentTarget.value === ASCENDING ? ASCENDING : DESCENDING);
   };
 
   return (

--- a/src/types/dust.ts
+++ b/src/types/dust.ts
@@ -11,7 +11,7 @@ type Flag = null | '통신장애';
 
 export type GradeType = 'NONE' | 'GOOD' | 'NORMAL' | 'BAD' | 'DANGER';
 
-export type SortType = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
+export type DustType = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 export type DustCode = typeof FINE_DUST_CODE | typeof ULTRA_FINE_DUST_CODE;
 export type DustImgCode =
   | typeof FINE_DUST_IMG_CODE

--- a/src/types/dust.ts
+++ b/src/types/dust.ts
@@ -11,6 +11,8 @@ type Flag = null | '통신장애';
 
 export type GradeType = 'NONE' | 'GOOD' | 'NORMAL' | 'BAD' | 'DANGER';
 
+export type SortType = 'DESCENDING' | 'ASCENDING';
+
 export type DustType = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 export type DustCode = typeof FINE_DUST_CODE | typeof ULTRA_FINE_DUST_CODE;
 export type DustImgCode =

--- a/src/types/dust.ts
+++ b/src/types/dust.ts
@@ -5,13 +5,15 @@ import {
   ULTRA_FINE_DUST,
   ULTRA_FINE_DUST_CODE,
   ULTRA_FINE_DUST_IMG_CODE,
+  ASCENDING,
+  DESCENDING,
 } from '@/utils/constants';
 
 type Flag = null | '통신장애';
 
 export type GradeType = 'NONE' | 'GOOD' | 'NORMAL' | 'BAD' | 'DANGER';
 
-export type SortType = 'DESCENDING' | 'ASCENDING';
+export type SortType = typeof DESCENDING | typeof ASCENDING;
 
 export type DustType = typeof FINE_DUST | typeof ULTRA_FINE_DUST;
 export type DustCode = typeof FINE_DUST_CODE | typeof ULTRA_FINE_DUST_CODE;

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -23,3 +23,4 @@ export {
 } from '@/utils/constants/map';
 export { BACKGROUND_ANIMATION, SCROLL_STYLE } from '@/utils/constants/style';
 export { ERROR_MESSAGE } from '@/utils/constants/message';
+export { SORT_TYPE } from '@/utils/constants/sort';

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -23,4 +23,4 @@ export {
 } from '@/utils/constants/map';
 export { BACKGROUND_ANIMATION, SCROLL_STYLE } from '@/utils/constants/style';
 export { ERROR_MESSAGE } from '@/utils/constants/message';
-export { SORT_TYPE } from '@/utils/constants/sort';
+export { SORT_TYPE, ASCENDING, DESCENDING } from '@/utils/constants/sort';

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -22,3 +22,4 @@ export {
   ZINDEX_MARKER_MOUSE_OUT,
 } from '@/utils/constants/map';
 export { BACKGROUND_ANIMATION, SCROLL_STYLE } from '@/utils/constants/style';
+export { SORT_TYPE } from '@/utils/constants/sort';

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -22,4 +22,4 @@ export {
   ZINDEX_MARKER_MOUSE_OUT,
 } from '@/utils/constants/map';
 export { BACKGROUND_ANIMATION, SCROLL_STYLE } from '@/utils/constants/style';
-export { SORT_TYPE } from '@/utils/constants/sort';
+export { SORT_TYPE, ASCENDING, DESCENDING } from '@/utils/constants/sort';

--- a/src/utils/constants/sort.ts
+++ b/src/utils/constants/sort.ts
@@ -1,1 +1,3 @@
-export const SORT_TYPE = ['오름차순', '내림차순'];
+export const ASCENDING = '오름차순';
+export const DESCENDING = '내림차순';
+export const SORT_TYPE = [ASCENDING, DESCENDING];

--- a/src/utils/constants/sort.ts
+++ b/src/utils/constants/sort.ts
@@ -1,1 +1,1 @@
-export const SORT_TYPE = ['DESCENDING', 'ASCENDING'];
+export const SORT_TYPE = ['오름차순', '내림차순'];

--- a/src/utils/constants/sort.ts
+++ b/src/utils/constants/sort.ts
@@ -1,0 +1,1 @@
+export const SORT_TYPE = ['DESCENDING', 'ASCENDING'];

--- a/src/utils/sortDustList.ts
+++ b/src/utils/sortDustList.ts
@@ -1,12 +1,12 @@
-import type { CityDustInfo, SidoDustInfo, SortType } from '@/types/dust';
+import type { CityDustInfo, SidoDustInfo, DustType } from '@/types/dust';
 import { FINE_DUST } from './constants/dust';
 
 export const sortDustList = <T extends SidoDustInfo | CityDustInfo>(
-  sortType: SortType,
+  DustType: DustType,
   data: T[]
 ) => {
   const scaleKey =
-    sortType === FINE_DUST ? 'fineDustScale' : 'ultraFineDustScale';
+    DustType === FINE_DUST ? 'fineDustScale' : 'ultraFineDustScale';
 
   return data.sort((a, b) => a[scaleKey] - b[scaleKey]);
 };

--- a/src/utils/sortDustList.ts
+++ b/src/utils/sortDustList.ts
@@ -1,12 +1,23 @@
-import type { CityDustInfo, SidoDustInfo, DustType } from '@/types/dust';
+import type {
+  CityDustInfo,
+  SidoDustInfo,
+  DustType,
+  SortType,
+} from '@/types/dust';
 import { FINE_DUST } from './constants/dust';
+import { ASCENDING } from './constants';
 
 export const sortDustList = <T extends SidoDustInfo | CityDustInfo>(
   DustType: DustType,
+  sortType: SortType,
   data: T[]
 ) => {
   const scaleKey =
     DustType === FINE_DUST ? 'fineDustScale' : 'ultraFineDustScale';
 
-  return data.sort((a, b) => a[scaleKey] - b[scaleKey]);
+  return data.sort((a, b) => {
+    const A = a[scaleKey];
+    const B = b[scaleKey];
+    return sortType === ASCENDING ? A - B : B - A;
+  });
 };


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #172 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 정렬 기준에 오름차순, 내림차순이 추가 되었습니다.
- context의 sortType을 dustType으로 이름 변경 하였습니다. 그리고 새로운 sortType을 추가하였습니다. 이제 dustType이 어느 먼지로 정렬할지 나타내고 sortType이 오름,내림 차순 정렬을 의미합니다.
- 기존 store에 미세먼지, 초미세먼지 정보를 담아서 정렬하던 것을 활용하였습니다.
- conponents > Ranking > SelectTabList 컴포넌트에서 onClick 함수도 prop으로 받도록 수정하였습니다. 

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 여주세요 -->
[chrome-capture-2023-5-30.webm](https://github.com/tooooo1/dust-rating/assets/12118892/34b4ba62-c201-4478-bb7c-9baa24cc261b)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 질문 <!-- 궁금한 부분을 적어주세요 -->
