### PR TITLE
Fix: sido 단위 마크를 클릭하면 해당 지역 랭킹 페이지로 이동

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -235,9 +235,9 @@ const Map = () => {
     SIDO_NAMES.includes(city)
       ? navigate(`${ROUTE.RANKING}/${city}`)
       : navigate(
-          `${ROUTE.DUST_FORECAST}?sido=${encodeURIComponent(
-            currentSido
-          )}&city=${encodeURIComponent(city)}`
+          `${ROUTE.DUST_FORECAST}?sido=
+            ${currentSido}
+          &city=${city}`
         );
   };
 

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -234,11 +234,7 @@ const Map = () => {
   const handleClickForeCastButton = () => {
     SIDO_NAMES.includes(city)
       ? navigate(`${ROUTE.RANKING}/${city}`)
-      : navigate(
-          `${ROUTE.DUST_FORECAST}?sido=
-            ${currentSido}
-          &city=${city}`
-        );
+      : navigate(`${ROUTE.DUST_FORECAST}?sido=${currentSido}&city=${city}`);
   };
 
   const handleClickGoBack = () => {

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -38,6 +38,7 @@ import {
   ZINDEX_MARKER_MOUSE_OVER,
   ZINDEX_MARKER_MOUSE_OUT,
   ROUTE,
+  SIDO_NAMES,
 } from '@/utils/constants';
 import ControlButton from './ControlButton';
 
@@ -231,11 +232,13 @@ const Map = () => {
   }, []);
 
   const handleClickForeCastButton = () => {
-    navigate(
-      `${ROUTE.DUST_FORECAST}?sido=${encodeURIComponent(
-        currentSido
-      )}&city=${encodeURIComponent(city)}`
-    );
+    SIDO_NAMES.includes(city)
+      ? navigate(`${ROUTE.RANKING}/${city}`)
+      : navigate(
+          `${ROUTE.DUST_FORECAST}?sido=${encodeURIComponent(
+            currentSido
+          )}&city=${encodeURIComponent(city)}`
+        );
   };
 
   const handleClickGoBack = () => {


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #179 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 기존에 지도에서 sido 단위 마커를 클릭했을 때 `dust-forecast?sido=서울&city=서울` 과 같이 비정상적인 url로 이동하던 문제를 수정했습니다. 이제 sido 단위 마커를 클릭하면 `ranking/서울` 처럼 이동됩니다.

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
[chrome-capture-2023-7-8.webm](https://github.com/tooooo1/dust-rating/assets/12118892/8f616a09-a162-46a6-be1b-bdb081d62fb7)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 질문 <!-- 궁금한 부분을 적어주세요 -->
- 클릭된 지역의 이름이 city라는 변수에 들어가 있기 때문에 sido 배열에서 city가 있다면 `ranking/city` 로 이동하도록 했는데 더 좋은 방법이 있을까요?