### PR TITLE
fix: GitHub 액션 오류 해결 및 PR 자동화 개선

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,5 +1,8 @@
-feature: ['feature/*', 'feat/*']
-fix: 'fix/*'
-refactor: 'refactor/*'
-chore: 'chore/*'
-document: ['document/*', 'docs/*']
+enhancement:
+  - src/**/*
+documentation:
+  - "**/*.md"
+dependencies:
+  - package*.json
+.github:
+  - .github/**/*

--- a/.github/workflows/assignor.yml
+++ b/.github/workflows/assignor.yml
@@ -1,17 +1,24 @@
-name: Assign Assignees and Reviewers
-
+name: Assign author
 on:
   pull_request:
-    types: [opened, ready_for_review]
-
+    types: [opened]
 jobs:
-  assign:
+  add-assignees:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
     steps:
-      - uses: hkusu/review-assign-action@v1
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Add assignee
+        uses: actions/github-script@v3
         with:
-          assignees: ${{ github.actor }}
-          reviewers: ${{ github.repository_owner }}
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addAssignees({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignees: [context.payload.pull_request.user.login]
+            })

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,20 +1,15 @@
-name: PR Labeler
+name: Labeler
 
 on:
-  pull_request:
-    types: [opened]
-
-permissions:
-  contents: read
+  - pull_request_target
 
 jobs:
-  pr-labeler:
+  triage:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
     steps:
-      - uses: TimonVS/pr-labeler-action@v4
+      - uses: actions/labeler@main
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: .github/labels.yml


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #181 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- GitHub 액션 중 `TimonVS/pr-labeler-action@v4`와 `hkusu/review-assign-action@v1` 실행 시 오류가 발생했습니다.
- "Resource not accessible by integration" 메시지와 "github-token"에 관한 문제가 나타났습니다.
- 이를 해결하기 위해 GitHub 토큰의 권한을 확인하고, .github 디렉토리의 설정 파일 경로와 내용을 점검했습니다.

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
<img width="861" alt="스크린샷 2023-08-17 오후 1 51 41" src="https://github.com/tooooo1/dust-rating/assets/77133565/4fc61626-7dd1-4883-a7e2-c46075d2fad4">

(`.github` 라벨이 없었어서 추가했어요. 라벨러도 잘됩니다.)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 액션의 오류를 성공적으로 해결했습니다.
- PR 라벨링 및 리뷰어 지정이 이제 자동으로 진행됩니다.


